### PR TITLE
Make sure to stop the patch after the test

### DIFF
--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -1742,6 +1742,9 @@ class SubprocessErrorTestCase(unittest.TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+    def tearDown(self):
+        patch.stopall()
+
     @patch('sys.stderr', new_callable=StringIO)
     def test_quality_reporter(self, mock_stderr):
         _patch_so_all_files_exist()


### PR DESCRIPTION
Failing to stop this patch was causing a bad interaction with coveragepy 5.0 as it depends on this function to check for the database it uses for its data