### PR TITLE
- no context in diff

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -50,7 +50,8 @@ class GitDiffTool(object):
             '-c', 'diff.noprefix=no',
             'diff', '{branch}{notation}HEAD'.format(branch=compare_branch, notation=self._range_notation),
             '--no-color',
-            '--no-ext-diff'
+            '--no-ext-diff',
+            '-U0'
         ])[0]
 
     def diff_unstaged(self):
@@ -67,7 +68,8 @@ class GitDiffTool(object):
             '-c', 'diff.noprefix=no',
             'diff',
             '--no-color',
-            '--no-ext-diff'
+            '--no-ext-diff',
+            '-U0'
         ])[0]
 
     def diff_staged(self):
@@ -85,5 +87,6 @@ class GitDiffTool(object):
             'diff',
             '--cached',
             '--no-color',
-            '--no-ext-diff'
+            '--no-ext-diff',
+            '-U0'
         ])[0]

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -30,7 +30,7 @@ class TestGitDiffTool(unittest.TestCase):
         # Expect that the correct command was executed
         expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
                     'diff.noprefix=no', 'diff', 'origin/master{}HEAD'.format(diff_range_notation),
-                    '--no-color', '--no-ext-diff']
+                    '--no-color', '--no-ext-diff', '-U0']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -48,7 +48,8 @@ class TestGitDiffTool(unittest.TestCase):
 
         # Expect that the correct command was executed
         expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
-                    'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff']
+                    'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff',
+                    '-U0']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -63,7 +64,7 @@ class TestGitDiffTool(unittest.TestCase):
         # Expect that the correct command was executed
         expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
                     'diff.noprefix=no', 'diff', '--cached', '--no-color',
-                    '--no-ext-diff']
+                    '--no-ext-diff', '-U0']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )
@@ -80,7 +81,7 @@ class TestGitDiffTool(unittest.TestCase):
         # Expect that the correct command was executed
         expected = ['git', '-c', 'diff.mnemonicprefix=no', '-c',
                     'diff.noprefix=no', 'diff', 'release...HEAD', '--no-color',
-                    '--no-ext-diff']
+                    '--no-ext-diff', '-U0']
         self.subprocess.Popen.assert_called_with(
             expected, stdout=self.subprocess.PIPE, stderr=self.subprocess.PIPE
         )


### PR DESCRIPTION
don't include any context in diff, so there is no report for lines
which aren't in fact failed