### PR TITLE
Handle removal of xml.etree.cElementTree in Python 3.9

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -7,7 +7,12 @@ import sys
 import argparse
 import six
 
-from xml.etree import cElementTree
+try:
+    # Needed for Python < 3.3, works up to 3.8
+    import xml.etree.cElementTree as etree
+except ImportError:
+    # Python 3.9 onwards
+    import xml.etree.ElementTree as etree
 
 from diff_cover import DESCRIPTION, VERSION
 from diff_cover.diff_reporter import GitDiffReporter
@@ -147,7 +152,7 @@ def generate_coverage_report(coverage_xml, compare_branch,
         ignore_staged=ignore_staged, ignore_unstaged=ignore_unstaged,
         exclude=exclude)
 
-    xml_roots = [cElementTree.parse(xml_root) for xml_root in coverage_xml]
+    xml_roots = [etree.parse(xml_root) for xml_root in coverage_xml]
     coverage = XmlCoverageReporter(xml_roots, src_roots)
 
     # Build a report generator

--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -4,7 +4,12 @@ from __future__ import unicode_literals
 import os
 import subprocess
 import sys
-import xml.etree.cElementTree as etree
+try:
+    # Needed for Python < 3.3, works up to 3.8
+    import xml.etree.cElementTree as etree
+except ImportError:
+    # Python 3.9 onwards
+    import xml.etree.ElementTree as etree
 from subprocess import Popen
 from textwrap import dedent
 

--- a/diff_cover/violationsreporters/java_violations_reporter.py
+++ b/diff_cover/violationsreporters/java_violations_reporter.py
@@ -6,7 +6,12 @@ from __future__ import unicode_literals
 import os
 from collections import defaultdict
 
-from xml.etree import cElementTree
+try:
+    # Needed for Python < 3.3, works up to 3.8
+    import xml.etree.cElementTree as etree
+except ImportError:
+    # Python 3.9 onwards
+    import xml.etree.ElementTree as etree
 from diff_cover.command_runner import run_command_for_code
 from diff_cover.git_path import GitPathTool
 from diff_cover.violationsreporters.base import BaseViolationReporter, Violation, RegexBasedDriver, QualityDriver
@@ -50,7 +55,7 @@ class CheckstyleXmlDriver(QualityDriver):
         """
         violations_dict = defaultdict(list)
         for report in reports:
-            xml_document = cElementTree.fromstring("".join(report))
+            xml_document = etree.fromstring("".join(report))
             files = xml_document.findall(".//file")
             for file_tree in files:
                 for error in file_tree.findall('error'):
@@ -91,7 +96,7 @@ class FindbugsXmlDriver(QualityDriver):
         """
         violations_dict = defaultdict(list)
         for report in reports:
-            xml_document = cElementTree.fromstring("".join(report))
+            xml_document = etree.fromstring("".join(report))
             bugs = xml_document.findall(".//BugInstance")
             for bug in bugs:
                 category = bug.get('category')
@@ -139,7 +144,7 @@ class PmdXmlDriver(QualityDriver):
         """
         violations_dict = defaultdict(list)
         for report in reports:
-            xml_document = cElementTree.fromstring("".join(report))
+            xml_document = etree.fromstring("".join(report))
             node_files = xml_document.findall(".//file")
             for node_file in node_files:
                 for error in node_file.findall('violation'):


### PR DESCRIPTION
In Python 3.9, xml.etree.cElementTree is gone (it has been
deprecated since 3.3). This adapts to that, retaining backwards
compatibility for Python 2 (if that's no longer considered
necessary we could of course simplify this).

Signed-off-by: Adam Williamson <awilliam@redhat.com>