### PR TITLE
Add support for outputting diff coverage as JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ You can also generate an HTML or JSON version of the report:
 .. code:: bash
 
     diff-cover coverage.xml --html-report report.html
-	diff-cover coverage.xml --json-report report.json
+    diff-cover coverage.xml --json-report report.json
 
 Multiple XML Coverage Reports
 -------------------------------

--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,12 @@ need to use different commands to generate the coverage XML report.
 This will compare the current ``git`` branch to ``origin/master`` and print
 the diff coverage report to the console.
 
-You can also generate an HTML version of the report:
+You can also generate an HTML or JSON version of the report:
 
 .. code:: bash
 
-	diff-cover coverage.xml --html-report report.html
+    diff-cover coverage.xml --html-report report.html
+	diff-cover coverage.xml --json-report report.json
 
 Multiple XML Coverage Reports
 -------------------------------
@@ -131,11 +132,12 @@ NOTE: There's no way to run ``findbugs`` from ``diff-quality`` as it operating
 over the generated java bytecode and should be integrated into the build
 framework.
 
-Like ``diff-cover``, HTML reports can be generated with
+Like ``diff-cover``, HTML and JSON reports can be generated with
 
 .. code:: bash
 
     diff-quality --violations=<tool> --html-report report.html
+    diff-quality --violations=<tool> --json-report report.json
 
 If you have already generated a report using ``pycodestyle``, ``pyflakes``, ``flake8``,
 ``pylint``, ``checkstyle``, ``checkstylexml``, or ``findbugs`` you can pass the report
@@ -360,11 +362,11 @@ Important notes:
 Special Thanks
 -------------------------
 
-Shout out to the original author of diff-cover `Will Daly 
-<https://github.com/wedaly>`_ and the original author of diff-quality `Sarina Canelake 
-<https://github.com/sarina>`_. 
+Shout out to the original author of diff-cover `Will Daly
+<https://github.com/wedaly>`_ and the original author of diff-quality `Sarina Canelake
+<https://github.com/sarina>`_.
 
-Originally created with the support of `edX 
+Originally created with the support of `edX
 <https://github.com/edx>`_.
 
 

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -18,10 +18,11 @@ from diff_cover import DESCRIPTION, VERSION
 from diff_cover.diff_reporter import GitDiffReporter
 from diff_cover.git_diff import GitDiffTool
 from diff_cover.git_path import GitPathTool
-from diff_cover.report_generator import HtmlReportGenerator, StringReportGenerator
+from diff_cover.report_generator import HtmlReportGenerator, StringReportGenerator, JsonReportGenerator
 from diff_cover.violationsreporters.violations_reporter import XmlCoverageReporter
 
 HTML_REPORT_HELP = "Diff coverage HTML output"
+JSON_REPORT_HELP = "Diff coverage JSON output"
 COMPARE_BRANCH_HELP = "Branch to compare"
 CSS_FILE_HELP = "Write CSS into an external file"
 FAIL_UNDER_HELP = "Returns an error code if coverage or quality score is below this value"
@@ -43,10 +44,11 @@ def parse_coverage_args(argv):
         {
             'coverage_xml': COVERAGE_XML,
             'html_report': None | HTML_REPORT,
+            'json_report': None | JSON_REPORT,
             'external_css_file': None | CSS_FILE,
         }
 
-    where `COVERAGE_XML`, `HTML_REPORT`, and `CSS_FILE` are paths.
+    where `COVERAGE_XML`, `HTML_REPORT`, `JSON_REPORT`, and `CSS_FILE` are paths.
 
     The path strings may or may not exist.
     """
@@ -59,12 +61,22 @@ def parse_coverage_args(argv):
         nargs='+'
     )
 
-    parser.add_argument(
+    output_format = parser.add_mutually_exclusive_group()
+
+    output_format.add_argument(
         '--html-report',
         metavar='FILENAME',
         type=str,
         default=None,
         help=HTML_REPORT_HELP
+    )
+
+    output_format.add_argument(
+        '--json-report',
+        metavar='FILENAME',
+        type=str,
+        default=None,
+        help=JSON_REPORT_HELP
     )
 
     parser.add_argument(
@@ -142,6 +154,7 @@ def parse_coverage_args(argv):
 
 def generate_coverage_report(coverage_xml, compare_branch,
                              html_report=None, css_file=None,
+                             json_report=None,
                              ignore_staged=False, ignore_unstaged=False,
                              exclude=None, src_roots=None, diff_range_notation=None):
     """
@@ -166,6 +179,11 @@ def generate_coverage_report(coverage_xml, compare_branch,
         if css_file is not None:
             with open(css_file, "wb") as output_file:
                 reporter.generate_css(output_file)
+
+    elif json_report is not None:
+        reporter = JsonReportGenerator(coverage, diff)
+        with open(json_report, "w") as output_file:
+            reporter.generate_report(output_file)
 
     reporter = StringReportGenerator(coverage, diff)
     output_file = sys.stdout if six.PY2 else sys.stdout.buffer
@@ -193,6 +211,7 @@ def main(argv=None, directory=None):
         arg_dict['coverage_xml'],
         arg_dict['compare_branch'],
         html_report=arg_dict['html_report'],
+        json_report=arg_dict['json_report'],
         css_file=arg_dict['external_css_file'],
         ignore_staged=arg_dict['ignore_staged'],
         ignore_unstaged=arg_dict['ignore_unstaged'],

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -182,7 +182,7 @@ def generate_coverage_report(coverage_xml, compare_branch,
 
     elif json_report is not None:
         reporter = JsonReportGenerator(coverage, diff)
-        with open(json_report, "w") as output_file:
+        with open(json_report, "wb") as output_file:
             reporter.generate_report(output_file)
 
     reporter = StringReportGenerator(coverage, diff)

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -218,7 +218,11 @@ TEMPLATE_ENV.filters['pluralize'] = pluralize_dj
 
 class JsonReportGenerator(BaseReportGenerator):
     def generate_report(self, output_file):
-        json.dump(self.report_dict(), output_file)
+        json_report_str = json.dumps(self.report_dict())
+
+        # all report generators are expected to write raw bytes, so we encode
+        # the json
+        output_file.write(json_report_str.encode())
 
 
 class TemplateReportGenerator(BaseReportGenerator):
@@ -296,7 +300,7 @@ class TemplateReportGenerator(BaseReportGenerator):
         else:
             snippet_style = None
 
-        context = super().report_dict()
+        context = super(TemplateReportGenerator, self).report_dict()
         context.update({
             'css_url': self.css_url,
             'snippet_style': snippet_style
@@ -335,7 +339,7 @@ class TemplateReportGenerator(BaseReportGenerator):
 
     def _src_path_stats(self, src_path):
 
-        stats = super()._src_path_stats(src_path)
+        stats = super(TemplateReportGenerator, self)._src_path_stats(src_path)
 
         # Load source snippets (if the report will display them)
         # If we cannot load the file, then fail gracefully

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -222,7 +222,7 @@ class JsonReportGenerator(BaseReportGenerator):
 
         # all report generators are expected to write raw bytes, so we encode
         # the json
-        output_file.write(json_report_str.encode())
+        output_file.write(json_report_str.encode('utf-8'))
 
 
 class TemplateReportGenerator(BaseReportGenerator):

--- a/diff_cover/tests/test_report_generator.py
+++ b/diff_cover/tests/test_report_generator.py
@@ -278,21 +278,23 @@ class JsonReportGeneratorTest(BaseReportGeneratorTest):
 
         # Verify that we got the expected string
         expected = json.dumps({
-            'report_name': 'Diff Coverage',
+            'report_name': ['reports/coverage.xml'],
             'diff_name': 'master',
             'src_stats': {
                 'file1.py': {
-                    'percent_covered': 66.7,
-                    'violation_lines': [10, 11]
+                    'percent_covered': 66.66666666666667,
+                    'violation_lines': [10, 11],
+                    'violations': [[10, None], [11, None]]
                 },
                 'subdir/file2.py': {
-                    'percent_covered': 66.7,
-                    'violation_lines': [10, 11]
+                    'percent_covered': 66.66666666666667,
+                    'violation_lines': [10, 11],
+                    'violations': [[10, None], [11, None]]
                 }
             },
             'total_num_lines': 12,
             'total_num_violations': 4,
-            'total_percent_covered': 66.7
+            'total_percent_covered': 66
         })
 
         self.assert_report(expected)
@@ -306,12 +308,13 @@ class JsonReportGeneratorTest(BaseReportGeneratorTest):
         self.set_measured('file.py', [2])
 
         expected = json.dumps({
-            'report_name': 'Diff Coverage',
+            'report_name': ['reports/coverage.xml'],
             'diff_name': 'master',
             'src_stats': {
                 'file.py': {
-                    'percent_covered': 100,
-                    'violation_lines': []
+                    'percent_covered': 100.0,
+                    'violation_lines': [],
+                    'violations': []
                 }
             },
             'total_num_lines': 1,
@@ -327,7 +330,7 @@ class JsonReportGeneratorTest(BaseReportGeneratorTest):
         # (this is the default)
 
         expected = json.dumps({
-            'report_name': 'Diff Coverage',
+            'report_name': ['reports/coverage.xml'],
             'diff_name': 'master',
             'src_stats': {},
             'total_num_lines': 0,


### PR DESCRIPTION
Adds a `--json-report` parameter to the executable to output the report results as JSON for ingestion by scripts and automations. To facilitate this with minimal code duplication, moves most non-HTML-related stat generation into the `BaseReportGenerator` class, keeping snippet logic and adjacent line combination in the `TemplateReportGenerator`.