### PR TITLE
Separate message in case of IOError/EnvironmentError

### DIFF
--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -269,9 +269,14 @@ def main(argv=None, directory=None):
                 LOGGER.error("Failure. Quality is below {}%.".format(fail_under))
                 return 1
 
-        except (ImportError, EnvironmentError):
+        except ImportError:
             LOGGER.error(
                 "Quality tool not installed: '{}'".format(tool)
+            )
+            return 1
+        except EnvironmentError as exc:
+            LOGGER.error(
+                "Failure: '{}'".format(exc)
             )
             return 1
         # Close any reports we opened


### PR DESCRIPTION
Running `diff-quality` command like this
`diff-quality  --violations=pylint --html-report test-results/pylint-report.html`
raises this error message `Quality tool not installed: 'pylint'`. which misleading when we `pylint` installed but html-report directory does not exist in this case `test-results`.
This PR separates the two exceptions to show more relavant error.