### PR TITLE
Properly declare non-support for Python 2.7. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     test_suite="nose.collector",
     description=DESCRIPTION,
     license="Apache 2.0",
-    python_requires="!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">= 3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
Partial fix for #159.

In addition to merging this change, something will need to be done with the releases in PyPI to make `pip2 install diff-cover` not pick up 4.0.0.