### PR TITLE
Remove universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Universal wheels are only meant for packages that support both Python 2 and Python 3:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

> Universal Wheels are wheels that are pure Python (i.e. contain no compiled extensions) and support Python 2 and 3. This is a wheel that can be installed anywhere by pip.