### PR TITLE
Resolve a few pylint issues

### DIFF
--- a/diff_cover/command_runner.py
+++ b/diff_cover/command_runner.py
@@ -8,8 +8,6 @@ class CommandError(Exception):
     Error raised when a command being executed returns an error
     """
 
-    pass
-
 
 def execute(command, exit_codes=[0]):
     """Execute provided command returning the stdout
@@ -67,5 +65,4 @@ def _ensure_unicode(text):
     """
     if isinstance(text, bytes):
         return text.decode(sys.getfilesystemencoding(), "replace")
-    else:
-        return text
+    return text

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -244,9 +244,8 @@ def main(argv=None, directory=None):
 
     if percent_covered >= fail_under:
         return 0
-    else:
-        LOGGER.error(f"Failure. Coverage is below {fail_under}%.")
-        return 1
+    LOGGER.error("Failure. Coverage is below %i%%.", fail_under)
+    return 1
 
 
 if __name__ == "__main__":

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -280,15 +280,15 @@ def main(argv=None, directory=None):
             )
             if percent_passing >= fail_under:
                 return 0
-            else:
-                LOGGER.error(f"Failure. Quality is below {fail_under}%.")
-                return 1
+
+            LOGGER.error("Failure. Quality is below %i.", fail_under)
+            return 1
 
         except ImportError:
-            LOGGER.error(f"Quality tool not installed: '{tool}'")
+            LOGGER.error("Quality tool not installed: '%s'", tool)
             return 1
         except OSError as exc:
-            LOGGER.error(f"Failure: '{exc}'")
+            LOGGER.error("Failure: '%s'", str(exc))
             return 1
         # Close any reports we opened
         finally:
@@ -296,7 +296,7 @@ def main(argv=None, directory=None):
                 file_handle.close()
 
     else:
-        LOGGER.error(f"Quality tool not recognized: '{tool}'")
+        LOGGER.error("Quality tool not recognized: '%s'", tool)
         return 1
 
 

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -2,11 +2,11 @@
 Classes for querying which lines have changed based on a diff.
 """
 from abc import ABCMeta, abstractmethod
-from diff_cover.git_diff import GitDiffError
 import fnmatch
 import glob
 import os
 import re
+from diff_cover.git_diff import GitDiffError
 
 
 class BaseDiffReporter:
@@ -34,7 +34,6 @@ class BaseDiffReporter:
 
         Source paths are guaranteed to be unique.
         """
-        pass
 
     @abstractmethod
     def lines_changed(self, src_path):
@@ -45,7 +44,6 @@ class BaseDiffReporter:
         Each line is guaranteed to be included only once in the list
         and in ascending order.
         """
-        pass
 
     def name(self):
         """
@@ -215,11 +213,11 @@ class GitDiffReporter(BaseDiffReporter):
                 # Parse the output of the diff string
                 diff_dict = self._parse_diff_str(diff_str)
 
-                for src_path in diff_dict.keys():
+                for src_path in diff_dict:
                     if self._is_path_excluded(src_path):
                         continue
                     # If no _supported_extensions provided, or extension present: process
-                    root, extension = os.path.splitext(src_path)
+                    _, extension = os.path.splitext(src_path)
                     extension = extension[1:].lower()
                     # 'not self._supported_extensions' tests for both None and empty list []
                     if (
@@ -427,9 +425,8 @@ class GitDiffReporter(BaseDiffReporter):
         if len(groups) == 1:
             return groups[0]
 
-        else:
-            msg = f"Could not parse source path in line '{line}'"
-            raise GitDiffError(msg)
+        msg = f"Could not parse source path in line '{line}'"
+        raise GitDiffError(msg)
 
     def _parse_hunk_line(self, line):
         """

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -10,8 +10,6 @@ class GitDiffError(Exception):
     `git diff` command produced an error.
     """
 
-    pass
-
 
 class GitDiffTool:
     """

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -2,11 +2,10 @@
 Classes for generating diff coverage reports.
 """
 from abc import ABCMeta, abstractmethod
-
+import json
 from jinja2 import Environment, PackageLoader
 from jinja2_pluralize import pluralize_dj
 from diff_cover.snippets import Snippet
-import json
 
 
 class DiffViolations:
@@ -61,7 +60,6 @@ class BaseReportGenerator:
         Concrete subclasses should access diff coverage info
         using the base class methods.
         """
-        pass
 
     def coverage_report_name(self):
         """
@@ -104,8 +102,7 @@ class BaseReportGenerator:
             num_uncovered = len(diff_violations.lines)
             return 100 - float(num_uncovered) / num_measured * 100
 
-        else:
-            return None
+        return None
 
     def violation_lines(self, src_path):
         """
@@ -155,8 +152,7 @@ class BaseReportGenerator:
             num_covered = total_lines - self.total_num_violations()
             return int(float(num_covered) / total_lines * 100)
 
-        else:
-            return 100
+        return 100
 
     def _diff_violations(self):
         """

--- a/diff_cover/snippets.py
+++ b/diff_cover/snippets.py
@@ -2,6 +2,7 @@
 Load snippets from source files to show violation lines
 in HTML reports.
 """
+from tokenize import open as openpy
 import chardet
 import pygments
 from pygments.formatters.html import HtmlFormatter
@@ -11,8 +12,6 @@ from pygments.lexers.special import TextLexer
 from pygments.util import ClassNotFound
 
 from diff_cover.git_path import GitPathTool
-
-from tokenize import open as openpy
 
 
 class Snippet:

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -563,12 +563,12 @@ class DiffQualityIntegrationTest(ToolsIntegrationBase):
 
         with patch("diff_cover.diff_quality_tool.LOGGER") as logger:
             exit_value = diff_quality_main(argv)
-            logger.error.assert_called_with(expected_error)
+            logger.error.assert_called_with(*expected_error)
             self.assertEqual(exit_value, 1)
 
     def test_tool_not_recognized(self):
         self._call_quality_expecting_error(
-            "garbage", "Quality tool not recognized: " "'garbage'"
+            "garbage", ("Quality tool not recognized: '%s'", "garbage"), "'garbage'"
         )
 
     def test_tool_not_installed(self):
@@ -579,7 +579,7 @@ class DiffQualityIntegrationTest(ToolsIntegrationBase):
         try:
             self._call_quality_expecting_error(
                 "not_installed",
-                "Failure: 'not_installed is not installed'",
+                ("Failure: '%s'", "not_installed is not installed"),
                 report_arg="",
             )
         finally:


### PR DESCRIPTION
This change resolves a few pylint warnings:
* useless pass statements (if a block has a docstring, no pass is needed)
* lazy formatting for logger (more efficent)
* else-after-return-if: If all paths above a else block return, the else block can be omitted
* fix import order

The lazy logging formatting lead to two test issues, which are fixed, too.