### PR TITLE
Fix a relative/absolute path bug with includes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,8 @@ Explicit exclusion of paths is possible for both ``diff-cover`` and ``diff-quali
 only supported for ``diff-quality`` (since 5.1.0).
 
 The exclude option works with ``fnmatch``, include with ``glob``. Both options can be specified multiple times.
+Include options should be wrapped in double quotes to prevent shell globbing. Also they should be relative to
+the current git directory.
 
 .. code:: bash
     diff-cover coverage.xml --exclude setup.py

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -81,11 +81,10 @@ class BaseDiffReporter:
         :returns:
             True if the patch should be excluded, otherwise False.
         """
-        absolute_path = os.path.abspath(path)
         include = self._include
         if include:
             for pattern in include:
-                if absolute_path in glob.glob(pattern, recursive=True):
+                if path in glob.glob(pattern, recursive=True):
                     break  # file is included
             else:
                 return True
@@ -97,6 +96,7 @@ class BaseDiffReporter:
         if self._fnmatch(basename, exclude):
             return True
 
+        absolute_path = os.path.abspath(path)
         match = self._fnmatch(absolute_path, exclude)
         return match
 

--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -79,10 +79,10 @@ class GitDiffReporterTest(unittest.TestCase):
             self._test_git_path_selection(include, exclude, expected)
 
     def _test_git_path_selection(self, include, exclude, expected):
+        old_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # because we don't want to mock glob completely, just make all patterns
-            # absolute (add tmp_dir to the start)
-            include = [f"{tmp_dir}/{path}" for path in include]
+            # change the working directory into the temp directory so that globs are working
+            os.chdir(tmp_dir)
 
             self.diff = GitDiffReporter(
                 git_diff=self._git_diff, exclude=exclude, include=include
@@ -120,6 +120,9 @@ class GitDiffReporterTest(unittest.TestCase):
             # Validate the source paths
             # They should be in alphabetical order
             self.assertEqual(source_paths, expected)
+
+        # change back to the previous working directory
+        os.chdir(old_cwd)
 
     def test_git_source_paths(self):
 


### PR DESCRIPTION
In the current implementation, the include option worked on the absolute path which makes no sense, because the path should be relative to the current git path.
This fix changes the usage from absolute_path to path. Also it adds some notice to the documentation.