### PR TITLE
Intent to use diff-cover outside git project

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -40,6 +40,7 @@ COVERAGE_XML_HELP = "XML coverage report"
 DIFF_RANGE_NOTATION_HELP = (
     "Git diff range notation to use when comparing branches, defaults to '...'"
 )
+WORK_TREE = "Hold the project directory name or path"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -152,6 +153,14 @@ def parse_coverage_args(argv):
         help=IGNORE_WHITESPACE,
     )
 
+    parser.add_argument(
+        "--work-tree",
+        metavar="WORKTREE",
+        type=str,
+        default=".",
+        help=WORK_TREE,
+    )
+
     return vars(parser.parse_args(argv))
 
 
@@ -168,13 +177,14 @@ def generate_coverage_report(
     src_roots=None,
     diff_range_notation=None,
     ignore_whitespace=False,
+    work_tree=None
 ):
     """
     Generate the diff coverage report, using kwargs from `parse_args()`.
     """
     diff = GitDiffReporter(
         compare_branch,
-        git_diff=GitDiffTool(diff_range_notation, ignore_whitespace),
+        git_diff=GitDiffTool(diff_range_notation, ignore_whitespace, work_tree),
         ignore_staged=ignore_staged,
         ignore_unstaged=ignore_unstaged,
         exclude=exclude,
@@ -240,6 +250,7 @@ def main(argv=None, directory=None):
         src_roots=arg_dict["src_roots"],
         diff_range_notation=arg_dict["diff_range_notation"],
         ignore_whitespace=arg_dict["ignore_whitespace"],
+        work_tree=arg_dict["work_tree"]
     )
 
     if percent_covered >= fail_under:

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -68,6 +68,7 @@ VIOLATION_CMD_HELP = "Which code quality tool to use (%s)" % "/".join(
 INPUT_REPORTS_HELP = "Which violations reports to use"
 OPTIONS_HELP = "Options to be passed to the violations tool"
 INCLUDE_HELP = "Files to include (glob pattern)"
+WORK_TREE = "Hold the project directory name or path"
 
 
 LOGGER = logging.getLogger(__name__)
@@ -166,7 +167,13 @@ def parse_quality_args(argv):
         default=False,
         help=IGNORE_WHITESPACE,
     )
-
+    parser.add_argument(
+        "--work-tree",
+        metavar="WORKTREE",
+        type=str,
+        default=".",
+        help=WORK_TREE,
+    )
     return vars(parser.parse_args(argv))
 
 
@@ -181,6 +188,7 @@ def generate_quality_report(
     include=None,
     diff_range_notation=None,
     ignore_whitespace=False,
+    work_tree=None,
 ):
     """
     Generate the quality report, using kwargs from `parse_args()`.
@@ -190,7 +198,7 @@ def generate_quality_report(
     )
     diff = GitDiffReporter(
         compare_branch,
-        git_diff=GitDiffTool(diff_range_notation, ignore_whitespace),
+        git_diff=GitDiffTool(diff_range_notation, ignore_whitespace, work_tree),
         ignore_staged=ignore_staged,
         ignore_unstaged=ignore_unstaged,
         supported_extensions=supported_extensions,
@@ -277,6 +285,7 @@ def main(argv=None, directory=None):
                 include=arg_dict["include"],
                 diff_range_notation=arg_dict["diff_range_notation"],
                 ignore_whitespace=arg_dict["ignore_whitespace"],
+                work_tree=arg_dict["work_tree"]
             )
             if percent_passing >= fail_under:
                 return 0

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -16,7 +16,7 @@ class GitDiffTool:
     Thin wrapper for a subset of the `git diff` command.
     """
 
-    def __init__(self, range_notation, ignore_whitespace):
+    def __init__(self, range_notation, ignore_whitespace, work_tree):
         """
         :param str range_notation:
             which range notation to use when producing the diff for committed
@@ -42,6 +42,8 @@ class GitDiffTool:
             "diff.mnemonicprefix=no",
             "-c",
             "diff.noprefix=no",
+            "--git-dir={directory}/.git".format(directory=work_tree),
+            "--work-tree={directory}".format(directory=work_tree)
         ]
 
         self._default_diff_args = ["diff", "--no-color", "--no-ext-diff", "-U0"]

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -15,7 +15,7 @@ class TestGitDiffTool(unittest.TestCase):
         self.subprocess.Popen.return_value = self.process
         self.addCleanup(mock.patch.stopall)
         # Create the git diff tool
-        self.tool = GitDiffTool(range_notation="...", ignore_whitespace=False)
+        self.tool = GitDiffTool(range_notation="...", ignore_whitespace=False, work_tree=None)
 
     def check_diff_committed(self, diff_range_notation, ignore_whitespace):
         self.tool = GitDiffTool(


### PR DESCRIPTION
In order to use `git diff` outside git dir, take `--work-tree` as a
diff-cover argument.