### PR TITLE
Add isort

### DIFF
--- a/diff_cover/command_runner.py
+++ b/diff_cover/command_runner.py
@@ -1,5 +1,4 @@
 import subprocess
-
 import sys
 
 

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -1,9 +1,7 @@
+import argparse
 import logging
-
 import os
 import sys
-import argparse
-
 import xml.etree.ElementTree as etree
 
 from diff_cover import DESCRIPTION, VERSION
@@ -12,9 +10,9 @@ from diff_cover.git_diff import GitDiffTool
 from diff_cover.git_path import GitPathTool
 from diff_cover.report_generator import (
     HtmlReportGenerator,
-    StringReportGenerator,
     JsonReportGenerator,
     MarkdownReportGenerator,
+    StringReportGenerator,
 )
 from diff_cover.violationsreporters.violations_reporter import XmlCoverageReporter
 

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -13,13 +13,13 @@ import diff_cover
 from diff_cover import hookspecs
 from diff_cover.diff_cover_tool import (
     COMPARE_BRANCH_HELP,
+    CSS_FILE_HELP,
     DIFF_RANGE_NOTATION_HELP,
+    EXCLUDE_HELP,
     FAIL_UNDER_HELP,
+    HTML_REPORT_HELP,
     IGNORE_STAGED_HELP,
     IGNORE_UNSTAGED_HELP,
-    EXCLUDE_HELP,
-    HTML_REPORT_HELP,
-    CSS_FILE_HELP,
     IGNORE_WHITESPACE,
 )
 from diff_cover.diff_reporter import GitDiffReporter
@@ -30,21 +30,21 @@ from diff_cover.report_generator import (
     StringQualityReportGenerator,
 )
 from diff_cover.violationsreporters.base import QualityReporter
-from diff_cover.violationsreporters.violations_reporter import (
-    CppcheckDriver,
-    flake8_driver,
-    pyflakes_driver,
-    PylintDriver,
-    jshint_driver,
-    eslint_driver,
-    pydocstyle_driver,
-    pycodestyle_driver,
-)
 from diff_cover.violationsreporters.java_violations_reporter import (
     CheckstyleXmlDriver,
-    checkstyle_driver,
     FindbugsXmlDriver,
     PmdXmlDriver,
+    checkstyle_driver,
+)
+from diff_cover.violationsreporters.violations_reporter import (
+    CppcheckDriver,
+    PylintDriver,
+    eslint_driver,
+    flake8_driver,
+    jshint_driver,
+    pycodestyle_driver,
+    pydocstyle_driver,
+    pyflakes_driver,
 )
 
 QUALITY_DRIVERS = {

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -1,11 +1,12 @@
 """
 Classes for querying which lines have changed based on a diff.
 """
-from abc import ABCMeta, abstractmethod
 import fnmatch
 import glob
 import os
 import re
+from abc import ABCMeta, abstractmethod
+
 from diff_cover.git_diff import GitDiffError
 
 

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -1,10 +1,12 @@
 """
 Classes for generating diff coverage reports.
 """
-from abc import ABCMeta, abstractmethod
 import json
+from abc import ABCMeta, abstractmethod
+
 from jinja2 import Environment, PackageLoader
 from jinja2_pluralize import pluralize_dj
+
 from diff_cover.snippets import Snippet
 
 

--- a/diff_cover/snippets.py
+++ b/diff_cover/snippets.py
@@ -3,6 +3,7 @@ Load snippets from source files to show violation lines
 in HTML reports.
 """
 from tokenize import open as openpy
+
 import chardet
 import pygments
 from pygments.formatters.html import HtmlFormatter

--- a/diff_cover/tests/helpers.py
+++ b/diff_cover/tests/helpers.py
@@ -1,10 +1,9 @@
 """
 Test helper functions.
 """
-import random
-
-import os.path
 import difflib
+import os.path
+import random
 
 HUNK_BUFFER = 2
 MAX_LINE_LENGTH = 300

--- a/diff_cover/tests/test_clover_violations_reporter.py
+++ b/diff_cover/tests/test_clover_violations_reporter.py
@@ -4,6 +4,7 @@ from io import StringIO
 from diff_cover.git_path import GitPathTool
 from diff_cover.violationsreporters.violations_reporter import XmlCoverageReporter
 
+
 # https://github.com/Bachmann1234/diff_cover/issues/190
 def test_get_src_path_clover():
     GitPathTool._cwd = "/"

--- a/diff_cover/tests/test_diff_quality_main.py
+++ b/diff_cover/tests/test_diff_quality_main.py
@@ -1,8 +1,7 @@
 import unittest
-
 from unittest.mock import patch
 
-from diff_cover.diff_quality_tool import parse_quality_args, main
+from diff_cover.diff_quality_tool import main, parse_quality_args
 
 
 class ParseQualityArgsTest(unittest.TestCase):

--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -1,12 +1,13 @@
-from unittest import mock
-import unittest
-import tempfile
 import os
+import tempfile
+import unittest
 from pathlib import Path
 from textwrap import dedent
+from unittest import mock
+
 from diff_cover.diff_reporter import GitDiffReporter
-from diff_cover.git_diff import GitDiffTool, GitDiffError
-from diff_cover.tests.helpers import line_numbers, git_diff_output
+from diff_cover.git_diff import GitDiffError, GitDiffTool
+from diff_cover.tests.helpers import git_diff_output, line_numbers
 
 
 class GitDiffReporterTest(unittest.TestCase):

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -1,8 +1,8 @@
+import unittest
 from unittest import mock
 
 from diff_cover.command_runner import CommandError
 from diff_cover.git_diff import GitDiffTool
-import unittest
 
 
 class TestGitDiffTool(unittest.TestCase):

--- a/diff_cover/tests/test_git_path.py
+++ b/diff_cover/tests/test_git_path.py
@@ -1,6 +1,7 @@
-from unittest import mock
-from diff_cover.git_path import GitPathTool
 import unittest
+from unittest import mock
+
+from diff_cover.git_path import GitPathTool
 
 
 class TestGitPathTool(unittest.TestCase):

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -12,8 +12,10 @@ import unittest
 from collections import defaultdict
 from io import BytesIO
 from subprocess import Popen
+from unittest.mock import Mock, patch
 
 import pylint
+
 from diff_cover.command_runner import CommandError
 from diff_cover.diff_cover_tool import main as diff_cover_main
 from diff_cover.diff_quality_tool import QUALITY_DRIVERS
@@ -21,7 +23,6 @@ from diff_cover.diff_quality_tool import main as diff_quality_main
 from diff_cover.git_path import GitPathTool
 from diff_cover.tests.helpers import assert_long_str_equal, fixture_path
 from diff_cover.violationsreporters.base import QualityDriver
-from unittest.mock import Mock, patch
 
 
 class ToolsIntegrationBase(unittest.TestCase):

--- a/diff_cover/tests/test_java_violations_reporter.py
+++ b/diff_cover/tests/test_java_violations_reporter.py
@@ -1,19 +1,18 @@
+import unittest
 from io import BytesIO
 from textwrap import dedent
-import unittest
 from unittest import mock
 from unittest.mock import patch
 
-from diff_cover.violationsreporters import base
-
 from diff_cover.command_runner import CommandError
+from diff_cover.violationsreporters import base
 from diff_cover.violationsreporters.base import QualityReporter
 from diff_cover.violationsreporters.java_violations_reporter import (
-    Violation,
-    checkstyle_driver,
     CheckstyleXmlDriver,
     FindbugsXmlDriver,
     PmdXmlDriver,
+    Violation,
+    checkstyle_driver,
 )
 
 

--- a/diff_cover/tests/test_report_generator.py
+++ b/diff_cover/tests/test_report_generator.py
@@ -1,20 +1,19 @@
+import json
+import unittest
 from io import BytesIO
 from textwrap import dedent
-import json
-
 from unittest import mock
 
 from diff_cover.diff_reporter import BaseDiffReporter
 from diff_cover.report_generator import (
     BaseReportGenerator,
     HtmlReportGenerator,
-    StringReportGenerator,
-    TemplateReportGenerator,
     JsonReportGenerator,
     MarkdownReportGenerator,
+    StringReportGenerator,
+    TemplateReportGenerator,
 )
-from diff_cover.tests.helpers import load_fixture, assert_long_str_equal
-import unittest
+from diff_cover.tests.helpers import assert_long_str_equal, load_fixture
 from diff_cover.violationsreporters.violations_reporter import (
     BaseViolationReporter,
     Violation,

--- a/diff_cover/tests/test_snippets.py
+++ b/diff_cover/tests/test_snippets.py
@@ -1,11 +1,13 @@
 import io
-from unittest import mock
 import os
 import tempfile
-from pygments.token import Token
-from diff_cover.snippets import Snippet
-from diff_cover.tests.helpers import load_fixture, fixture_path, assert_long_str_equal
 import unittest
+from unittest import mock
+
+from pygments.token import Token
+
+from diff_cover.snippets import Snippet
+from diff_cover.tests.helpers import assert_long_str_equal, fixture_path, load_fixture
 
 
 class SnippetTest(unittest.TestCase):

--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -9,29 +9,28 @@ try:
 except ImportError:
     # Python 3.9 onwards
     import xml.etree.ElementTree as etree
+
+import unittest
 from subprocess import Popen
 from textwrap import dedent
-
 from unittest import mock
-
-from diff_cover.violationsreporters import base
+from unittest.mock import MagicMock, Mock, patch
 
 from diff_cover.command_runner import CommandError, run_command_for_code
-import unittest
+from diff_cover.violationsreporters import base
 from diff_cover.violationsreporters.base import QualityReporter
 from diff_cover.violationsreporters.violations_reporter import (
-    XmlCoverageReporter,
-    Violation,
-    pycodestyle_driver,
-    pyflakes_driver,
-    flake8_driver,
-    PylintDriver,
-    jshint_driver,
-    eslint_driver,
-    pydocstyle_driver,
     CppcheckDriver,
+    PylintDriver,
+    Violation,
+    XmlCoverageReporter,
+    eslint_driver,
+    flake8_driver,
+    jshint_driver,
+    pycodestyle_driver,
+    pydocstyle_driver,
+    pyflakes_driver,
 )
-from unittest.mock import Mock, patch, MagicMock
 
 
 def _patch_so_all_files_exist():

--- a/diff_cover/violationsreporters/base.py
+++ b/diff_cover/violationsreporters/base.py
@@ -1,13 +1,9 @@
-from abc import ABCMeta, abstractmethod
-from collections import defaultdict, namedtuple
-
-
 import copy
-
+import os
 import re
 import sys
-import os
-
+from abc import ABCMeta, abstractmethod
+from collections import defaultdict, namedtuple
 
 from diff_cover.command_runner import execute, run_command_for_code
 

--- a/diff_cover/violationsreporters/java_violations_reporter.py
+++ b/diff_cover/violationsreporters/java_violations_reporter.py
@@ -11,15 +11,14 @@ try:
 except ImportError:
     # Python 3.9 onwards
     import xml.etree.ElementTree as etree
+
 from diff_cover.command_runner import run_command_for_code
 from diff_cover.git_path import GitPathTool
 from diff_cover.violationsreporters.base import (
-    BaseViolationReporter,
-    Violation,
-    RegexBasedDriver,
     QualityDriver,
+    RegexBasedDriver,
+    Violation,
 )
-
 
 """
     Report checkstyle violations.

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -2,19 +2,19 @@
 Classes for querying the information in a test coverage report.
 """
 
+import itertools
+import os
+import posixpath
 import re
 from collections import defaultdict
 
-import os
-import itertools
-import posixpath
 from diff_cover.command_runner import run_command_for_code
 from diff_cover.git_path import GitPathTool
 from diff_cover.violationsreporters.base import (
     BaseViolationReporter,
-    Violation,
-    RegexBasedDriver,
     QualityDriver,
+    RegexBasedDriver,
+    Violation,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ exclude = '''
   | diff_cover/tests/fixtures/*
 )
 '''
+
+[tool.isort]
+profile = "black"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,4 +8,5 @@ pylint
 pydocstyle
 tox==3.23.1
 black
+isort
 -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     -r{toxinidir}/test-requirements.txt
 commands =
     black diff_cover
+    isort diff_cover
     python -m pytest --cov --cov-report=xml {posargs}
     git fetch origin master:refs/remotes/origin/master
     diff-cover coverage.xml


### PR DESCRIPTION
This change adds isort to keep the sorting of imports stable and apply the logic automatically.
Because this project uses black as well, isort is configured to work right with black (see https://pycqa.github.io/isort/docs/configuration/black_compatibility/ for details)