### PR TITLE
Improve usage of flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length=100
+select=
+    C901,  # flake8-mccabe
+    E,  # flake8-pycodestyle
+    F,  # flake8-pyflakes
+    W,  # flake8-pycodestyle
+ignore =
+    W503,E203,  # conflict with black formatter
+per-file-ignores =
+    # supression for __init__
+    diff_cover/tests/*: E501
+    diff_cover/tests/fixtures/*: E,F,W

--- a/diff_cover/command_runner.py
+++ b/diff_cover/command_runner.py
@@ -13,8 +13,8 @@ def execute(command, exit_codes=[0]):
     Args:
         command (list[str]): list of tokens to execute as your command.
         exit_codes (list[int]): exit codes which do not indicate error.
-        subprocess_mod (module): Defaults to pythons subprocess module but you can optionally pass in
-        another. This is mostly for testing purposes
+        subprocess_mod (module): Defaults to pythons subprocess module but you can optionally pass
+        in another. This is mostly for testing purposes
     Returns:
         str - Stdout of the command passed in. This will be Unicode for python < 3. Str for python 3
     Raises:

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -232,7 +232,7 @@ class GitDiffReporter(BaseDiffReporter):
                         result_dict[src_path] = [
                             line
                             for line in result_dict.get(src_path, [])
-                            if not line in deleted_lines
+                            if line not in deleted_lines
                         ] + added_lines
 
             # Eliminate repeats and order line numbers

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -22,15 +22,18 @@ class GitDiffTool:
             which range notation to use when producing the diff for committed
             files against another branch.
 
-            Traditionally in git-cover the symmetric difference (three-dot, "A...M") notation has been used: it
-            includes commits reachable from A and M from their merge-base, but not both, taking history in account.
-            This includes cherry-picks between A and M, which are harmless and do not produce changes, but might give
-            inaccurate coverage false-negatives.
+            Traditionally in git-cover the symmetric difference (three-dot, "A...M") notation has
+            been used:
+            it includes commits reachable from A and M from their merge-base, but not both,
+            taking history in account.
+            This includes cherry-picks between A and M, which are harmless and do not produce
+            changes, but might give inaccurate coverage false-negatives.
 
-            Two-dot range notation ("A..M") compares the tips of both trees and produces a diff. This more accurately
-            describes the actual patch that will be applied by merging A into M, even if commits have been
-            cherry-picked between branches. This will produce a more accurate diff for coverage comparison when
-            complex merges and cherry-picks are involved.
+            Two-dot range notation ("A..M") compares the tips of both trees and produces a diff.
+            This more accurately describes the actual patch that will be applied by merging A into
+            M, even if commits have been cherry-picked between branches.
+            This will produce a more accurate diff for coverage comparison when complex merges and
+            cherry-picks are involved.
 
          :param bool ignore_whitespace:
             Perform a diff but ignore any and all whitespace.

--- a/diff_cover/tests/test_integration.py
+++ b/diff_cover/tests/test_integration.py
@@ -2,7 +2,6 @@
 High-level integration tests of diff-cover tool.
 """
 
-import io
 import os
 import os.path
 import re
@@ -13,8 +12,6 @@ from collections import defaultdict
 from io import BytesIO
 from subprocess import Popen
 from unittest.mock import Mock, patch
-
-import pylint
 
 from diff_cover.command_runner import CommandError
 from diff_cover.diff_cover_tool import main as diff_cover_main

--- a/diff_cover/tests/test_report_generator.py
+++ b/diff_cover/tests/test_report_generator.py
@@ -514,7 +514,7 @@ class MarkdownReportGeneratorTest(BaseReportGeneratorTest):
         - file&#46;py (100%)
 
         ## Summary
-        
+
         - **Total**: 1 line
         - **Missing**: 0 lines
         - **Coverage**: 100%

--- a/diff_cover/tests/test_snippets.py
+++ b/diff_cover/tests/test_snippets.py
@@ -1,4 +1,3 @@
-import io
 import os
 import tempfile
 import unittest

--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -793,7 +793,7 @@ class pycodestyleQualityReporterTest(unittest.TestCase):
     def test_quality(self):
 
         # Patch the output of `pycodestyle`
-        _mock_communicate = patch.object(Popen, "communicate").start()
+        patch.object(Popen, "communicate").start()
         return_string = (
             "\n"
             + dedent(

--- a/diff_cover/violationsreporters/base.py
+++ b/diff_cover/violationsreporters/base.py
@@ -110,7 +110,7 @@ class QualityReporter(BaseViolationReporter):
         """
         Args:
             driver (QualityDriver) object that works with the underlying quality tool
-            reports (list[file]) pre-generated reports. If not provided the tool will be run instead.
+            reports (list[file]) pre-generated reports. If not provided the tool will be run instead
             options (str) options to be passed into the command
         """
         super().__init__(driver.name)

--- a/diff_cover/violationsreporters/java_violations_reporter.py
+++ b/diff_cover/violationsreporters/java_violations_reporter.py
@@ -129,7 +129,9 @@ class FindbugsXmlDriver(QualityDriver):
     def installed(self):
         """
         Method checks if the provided tool is installed.
-        Returns: boolean False: As findbugs analyses bytecode, it would be hard to run it from outside the build framework.
+        Returns:
+            boolean False: As findbugs analyses bytecode,
+            it would be hard to run it from outside the build framework.
         """
         return False
 
@@ -167,6 +169,8 @@ class PmdXmlDriver(QualityDriver):
     def installed(self):
         """
         Method checks if the provided tool is installed.
-        Returns: boolean False: As findbugs analyses bytecode, it would be hard to run it from outside the build framework.
+        Returns:
+            boolean False: As findbugs analyses bytecode,
+            it would be hard to run it from outside the build framework.
         """
         return False

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -378,7 +378,7 @@ class PylintDriver(QualityDriver):
             ],
             # Pylint returns bit-encoded exit codes as documented here:
             # https://pylint.readthedocs.io/en/latest/user_guide/run.html
-            # 1 = fatal error, if an error occurred which prevented pylint from doing further processing
+            # 1 = fatal error, occurs if an error prevents pylint from doing further processing
             # 2,4,8,16 = error/warning/refactor/convention message issued
             # 32 = usage error
             [

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,5 @@ commands =
     python -m pytest --cov --cov-report=xml {posargs}
     git fetch origin master:refs/remotes/origin/master
     diff-cover coverage.xml
-    diff-quality --violation=pycodestyle
-    diff-quality --violation=pyflakes
+    diff-quality --violation=flake8
     diff-quality --violation=pylint


### PR DESCRIPTION
This change improves the project internal usage of flake8.
* First, instead of running pydocstyle and pyflakes standalone, we could use flake8 directly
* Second, a configuration for flake8 was added
* Third: existing flake8 vialoations are now resolved. This means, running 'flake8 diff_cover' doesn't return any error