### PR TITLE
Simplify pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,25 +2,7 @@
 line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | diff_cover/tests/fixtures/*
-)
-'''
+exclude = "diff_cover/tests/fixtures/*"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The black command is always executed on 'diff_cover' therefore we don't need to maintain a big exclude list.
So, exclude only needs to contain python files/directories which are part of 'diff_cover'