### PR TITLE
Improve flake8 regex

### DIFF
--- a/diff_cover/tests/test_violations_reporter.py
+++ b/diff_cover/tests/test_violations_reporter.py
@@ -1102,6 +1102,7 @@ class Flake8QualityReporterTest(unittest.TestCase):
                 ../new_file.py:90:0: D207 Docstring is under-indented
                 ../new_file.py:100:0: S100 Snippet found
                 ../new_file.py:110:0: Q000 Remove Single quotes
+                ../new_file.py:120:0: ABCXYZ000 Dummy
             """
             ).strip()
             + "\n"
@@ -1133,6 +1134,7 @@ class Flake8QualityReporterTest(unittest.TestCase):
             Violation(90, "D207 Docstring is under-indented"),
             Violation(100, "S100 Snippet found"),
             Violation(110, "Q000 Remove Single quotes"),
+            Violation(120, "ABCXYZ000 Dummy"),
         ]
 
         self.assertEqual(expected_violations, quality.violations("../new_file.py"))

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -298,24 +298,14 @@ pyflakes_driver = RegexBasedDriver(
 
 """
     Report Flake8 violations.
-
-    Flake8 warning/error codes:
-        E***/W***: pycodestyle errors and warnings
-        F***: pyflakes codes
-        C9**: mccabe complexity plugin
-        N8**: pycodestyle-naming plugin
-        T000: flake8-todo plugin
-
-    http://flake8.readthedocs.org/en/latest/warnings.html
 """
 flake8_driver = RegexBasedDriver(
     name="flake8",
     supported_extensions=["py"],
     command=["flake8"],
     # Match lines of the form:
-    # path/to/file.py:328: undefined name '_thing'
-    # path/to/file.py:418: 'random' imported but unused
-    expression=r"^([^:]+):(\d+).*([EWFCNTIBDSQ]\d{3}.*)$",
+    # new_file.py:1:17: E231 whitespace
+    expression=r"^([^:]+):(\d+):(?:\d+): ([a-zA-Z]+\d+.*)$",
     command_to_check_install=["flake8", "--version"],
     # flake8 exit code is 1 if there are violations
     # http://flake8.pycqa.org/en/latest/user/invocation.html


### PR DESCRIPTION
According to the flake8 documentation, it's recommended that the error code has 3 letters and 3 digits.
However this is just recommendation, so there are checks with one, two, three and even more letters.

This change improves the regex of the flake8 driver:
* Add non-capturing group for the column (needed to remove the following dot-star)
* Replace the dot-star with a colon and a space
* Allow any number of letters for the error group (and be so nice to also allow lowercase letters)
* Allow any number of numbers to follow the error code