### PR TITLE
Migrate test_git_diff to native pytest

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,7 +16,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_pytest
 
 
 [MESSAGES CONTROL]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,12 @@
 # Common requirements for developing on all supported python versions
 mock
 pytest-cov
+pytest-mock
 pycodestyle>=2.4.0
 flake8
 pyflakes
 pylint
+pylint-pytest
 pydocstyle
 tox==3.23.1
 black


### PR DESCRIPTION
This change migrates test_git_diff to native pytest:

- Split setUp into fixtrues
- Make utility functions fixtures, too
- Use native pytest assert
- Add pytest-mock to test dependencies (get rid of unittest.mock and mock in the long run)  -> pytest-mock is a nice wrapper around unittest.mock but avoids start/stop and contextmanagers. Also it adds some nice utility functions
- Add pylint-pytest to avoid false positive errors in pylint