### PR TITLE
Switch to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ need to use different commands to generate the coverage XML report.
 
     diff-cover coverage.xml
 
-This will compare the current ``git`` branch to ``origin/master`` and print
+This will compare the current ``git`` branch to ``origin/main`` and print
 the diff coverage report to the console.
 
 You can also generate an HTML, JSON or Markdown version of the report:
@@ -183,7 +183,7 @@ If you need to pass in additional options you can with the ``options`` flag
 Compare Branch
 --------------
 
-By default, ``diff-cover`` compares the current branch to ``origin/master``.  To specify a different compare branch:
+By default, ``diff-cover`` compares the current branch to ``origin/main``.  To specify a different compare branch:
 
 .. code:: bash
 
@@ -252,17 +252,17 @@ __ http://nedbatchelder.com/code/coverage/
 
 .. code:: bash
 
-    fatal: ambiguous argument 'origin/master...HEAD': unknown revision or path not in the working tree.
+    fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree.
 
 This is known to occur when running ``diff-cover`` in `Travis CI`__
 
 __ http://travis-ci.org
 
-**Solution**: Fetch the remote master branch before running ``diff-cover``:
+**Solution**: Fetch the remote main branch before running ``diff-cover``:
 
 .. code:: bash
 
-    git fetch origin master:refs/remotes/origin/master
+    git fetch origin master:refs/remotes/origin/main
 
 **Issue**: ``diff-quality`` reports "diff_cover.violations_reporter.QualityReporterError: No config file found, using default configuration"
 

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -100,7 +100,7 @@ def parse_coverage_args(argv):
         "--compare-branch",
         metavar="BRANCH",
         type=str,
-        default="origin/master",
+        default="origin/main",
         help=COMPARE_BRANCH_HELP,
     )
 

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -114,7 +114,7 @@ def parse_quality_args(argv):
         "--compare-branch",
         metavar="BRANCH",
         type=str,
-        default="origin/master",
+        default="origin/main",
         help=COMPARE_BRANCH_HELP,
     )
 

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -109,7 +109,7 @@ class GitDiffReporter(BaseDiffReporter):
 
     def __init__(
         self,
-        compare_branch="origin/master",
+        compare_branch="origin/main",
         git_diff=None,
         ignore_staged=None,
         ignore_unstaged=None,

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -53,10 +53,10 @@ class GitDiffTool:
             self._default_diff_args.append("--ignore-all-space")
             self._default_diff_args.append("--ignore-blank-lines")
 
-    def diff_committed(self, compare_branch="origin/master"):
+    def diff_committed(self, compare_branch="origin/main"):
         """
         Returns the output of `git diff` for committed
-        changes not yet in origin/master.
+        changes not yet in origin/main.
 
         Raises a `GitDiffError` if `git diff` outputs anything
         to stderr.

--- a/diff_cover/tests/fixtures/add_console_report.txt
+++ b/diff_cover/tests/fixtures/add_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/add_html_report.html
+++ b/diff_cover/tests/fixtures/add_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/changed_console_report.txt
+++ b/diff_cover/tests/fixtures/changed_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 test_src.txt (100%)
 -------------

--- a/diff_cover/tests/fixtures/changed_html_report.html
+++ b/diff_cover/tests/fixtures/changed_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 1 line</li>
             <li><b>Missing</b>: 0 lines</li>

--- a/diff_cover/tests/fixtures/delete_console_report.txt
+++ b/diff_cover/tests/fixtures/delete_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 No lines with coverage information in this diff.
 -------------

--- a/diff_cover/tests/fixtures/delete_html_report.html
+++ b/diff_cover/tests/fixtures/delete_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <p>No lines with coverage information in this diff.</p>
     </body>
 </html>

--- a/diff_cover/tests/fixtures/dotnet_coverage_console_report.txt
+++ b/diff_cover/tests/fixtures/dotnet_coverage_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 SampleApp/Sample.cs (0.0%): Missing lines 23-25
 -------------

--- a/diff_cover/tests/fixtures/empty_pycodestyle_violations.txt
+++ b/diff_cover/tests/fixtures/empty_pycodestyle_violations.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pycodestyle
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (100%)
 -------------

--- a/diff_cover/tests/fixtures/external_css_html_report.html
+++ b/diff_cover/tests/fixtures/external_css_html_report.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 1 line</li>
             <li><b>Missing</b>: 0 lines</li>

--- a/diff_cover/tests/fixtures/lua_console_report.txt
+++ b/diff_cover/tests/fixtures/lua_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 scripts/maths.lua (50.0%): Missing lines 12
 -------------

--- a/diff_cover/tests/fixtures/moved_console_report.txt
+++ b/diff_cover/tests/fixtures/moved_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/moved_html_report.html
+++ b/diff_cover/tests/fixtures/moved_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/mult_inputs_console_report.txt
+++ b/diff_cover/tests/fixtures/mult_inputs_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 test_src.txt (60.0%): Missing lines 4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/mult_inputs_html_report.html
+++ b/diff_cover/tests/fixtures/mult_inputs_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 4 lines</li>

--- a/diff_cover/tests/fixtures/pycodestyle_violations_report.html
+++ b/diff_cover/tests/fixtures/pycodestyle_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pycodestyle</p>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pycodestyle_violations_report.txt
+++ b/diff_cover/tests/fixtures/pycodestyle_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pycodestyle
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (66.7%):
 violations_test_file.py:2: E225 missing whitespace around operator

--- a/diff_cover/tests/fixtures/pycodestyle_violations_report_external_css.html
+++ b/diff_cover/tests/fixtures/pycodestyle_violations_report_external_css.html
@@ -8,7 +8,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pycodestyle</p>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pyflakes_two_files.txt
+++ b/diff_cover/tests/fixtures/pyflakes_two_files.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pyflakes
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 hello.py (0.0%):
 hello.py:2: undefined name 'unknown_var'

--- a/diff_cover/tests/fixtures/pyflakes_violations_report.html
+++ b/diff_cover/tests/fixtures/pyflakes_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pyflakes</p>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pyflakes_violations_report.txt
+++ b/diff_cover/tests/fixtures/pyflakes_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pyflakes
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (88.9%):
 violations_test_file.py:11: local variable 'unused' is assigned to but never used

--- a/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_dupe_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 fileone.py (93.8%):
 fileone.py:3: R0801: (duplicate-code), : Similar lines in 2 files

--- a/diff_cover/tests/fixtures/pylint_violations_console_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_console_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (77.8%):
 violations_test_file.py:1: C0114: (missing-module-docstring), : Missing module docstring

--- a/diff_cover/tests/fixtures/pylint_violations_report.html
+++ b/diff_cover/tests/fixtures/pylint_violations_report.html
@@ -77,7 +77,7 @@
     <body>
         <h1>Diff Quality</h1>
         <p>Quality Report: pylint</p>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <table border="1">
             <tr>
                 <th>Source File</th>

--- a/diff_cover/tests/fixtures/pylint_violations_report.txt
+++ b/diff_cover/tests/fixtures/pylint_violations_report.txt
@@ -1,7 +1,7 @@
 -------------
 Diff Quality
 Quality Report: pylint
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 violations_test_file.py (77.8%):
 violations_test_file.py:1: C0111: Missing docstring

--- a/diff_cover/tests/fixtures/show_uncovered_lines_console.txt
+++ b/diff_cover/tests/fixtures/show_uncovered_lines_console.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/subdir_coverage_console_report.txt
+++ b/diff_cover/tests/fixtures/subdir_coverage_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 sub/test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/subdir_coverage_html_report.html
+++ b/diff_cover/tests/fixtures/subdir_coverage_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/fixtures/unicode_console_report.txt
+++ b/diff_cover/tests/fixtures/unicode_console_report.txt
@@ -1,6 +1,6 @@
 -------------
 Diff Coverage
-Diff: origin/master...HEAD, staged and unstaged changes
+Diff: origin/main...HEAD, staged and unstaged changes
 -------------
 unicode_test_src.txt (50.0%): Missing lines 2,4,6,8,10
 -------------

--- a/diff_cover/tests/fixtures/unicode_html_report.html
+++ b/diff_cover/tests/fixtures/unicode_html_report.html
@@ -76,7 +76,7 @@
     </head>
     <body>
         <h1>Diff Coverage</h1>
-        <p>Diff: origin/master...HEAD, staged and unstaged changes</p>
+        <p>Diff: origin/main...HEAD, staged and unstaged changes</p>
         <ul>
             <li><b>Total</b>: 10 lines</li>
             <li><b>Missing</b>: 5 lines</li>

--- a/diff_cover/tests/test_diff_reporter.py
+++ b/diff_cover/tests/test_diff_reporter.py
@@ -23,7 +23,7 @@ class GitDiffReporterTest(unittest.TestCase):
 
         # Expect that diff report is named after its compare branch
         self.assertEqual(
-            self.diff.name(), "origin/master...HEAD, staged and unstaged changes"
+            self.diff.name(), "origin/main...HEAD, staged and unstaged changes"
         )
 
     def test_name_compare_branch(self):
@@ -37,14 +37,14 @@ class GitDiffReporterTest(unittest.TestCase):
         # Override the default branch
         self.assertEqual(
             GitDiffReporter(git_diff=self._git_diff, ignore_staged=True).name(),
-            "origin/master...HEAD and unstaged changes",
+            "origin/main...HEAD and unstaged changes",
         )
 
     def test_name_ignore_unstaged(self):
         # Override the default branch
         self.assertEqual(
             GitDiffReporter(git_diff=self._git_diff, ignore_unstaged=True).name(),
-            "origin/master...HEAD and staged changes",
+            "origin/main...HEAD and staged changes",
         )
 
     def test_name_ignore_staged_and_unstaged(self):
@@ -53,7 +53,7 @@ class GitDiffReporterTest(unittest.TestCase):
             GitDiffReporter(
                 git_diff=self._git_diff, ignore_staged=True, ignore_unstaged=True
             ).name(),
-            "origin/master...HEAD",
+            "origin/main...HEAD",
         )
 
     def test_git_path_selection(self):

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -128,6 +128,22 @@ def test_diff_staged(tool, subprocess, set_git_diff_output):
     )
 
 
+def test_diff_missing_branch_error(set_git_diff_output, tool, subprocess):
+    # Override the default compare branch
+    set_git_diff_output("test output", "fatal error", 1)
+    with pytest.raises(CommandError):
+        tool.diff_committed(compare_branch="release")
+
+    set_git_diff_output(
+        "test output",
+        "ambiguous argument 'origin/master...HEAD': "
+        "unknown revision or path not in the working tree.",
+        1,
+    )
+    with pytest.raises(ValueError):
+        tool.diff_committed(compare_branch="release")
+
+
 def test_diff_committed_compare_branch(set_git_diff_output, tool, subprocess):
     # Override the default compare branch
     set_git_diff_output("test output", "")

--- a/diff_cover/tests/test_git_diff.py
+++ b/diff_cover/tests/test_git_diff.py
@@ -64,7 +64,7 @@ def check_diff_committed(subprocess, set_git_diff_output):
         if ignore_whitespace:
             expected.append("--ignore-all-space")
             expected.append("--ignore-blank-lines")
-        expected.append(f"origin/master{diff_range_notation}HEAD")
+        expected.append(f"origin/main{diff_range_notation}HEAD")
         subprocess.Popen.assert_called_with(
             expected, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ commands =
     isort diff_cover
     python -m pytest --cov --cov-report=xml {posargs}
     git fetch origin master:refs/remotes/origin/master
-    diff-cover coverage.xml
-    diff-quality --violation=flake8
-    diff-quality --violation=pylint
+    diff-cover coverage.xml --compare-branch origin/master
+    diff-quality --violation=flake8 --compare-branch origin/master
+    diff-quality --violation=pylint --compare-branch origin/master


### PR DESCRIPTION
This will be a breaking change so ill release it under a major version number.

Git is actively working to move its default branch from master to main
Github has already done so
Gitlab I believe has done so as well.

This PR changes this tool to look for main by default. To help existing users I have caught the error and provided a specific workaround for users who's branch still uses master as the root it looks like the following

```
ValueError:
Could not find the branch to compare to. Does 'origin/main' exist?
the `--compare-branch` argument allows you to set a different branch.
```
