### PR TITLE
Allow diff-cover to see untracked files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,15 @@ The following is executed for every changed file:
 #. if yes, check if the changed file is part of at least one include pattern
 #. check if the file is part of any exclude pattern
 
+Ignore/Include based on file status in git
+------------------------------------------
+Both ``diff-cover`` and ``diff-quality`` allow users to ignore and include files based on the git
+status: staged, unstaged, untracked:
+
+* ``--ignore-staged``: ignore all staged files (by default include them)
+* ``--ignore-unstaged``: ignore all unstaged files (by default include them)
+* ``--include-untracked``: include all untracked files (by default ignore them)
+
 Quiet mode
 ----------
 Both ``diff-cover`` and ``diff-quality`` support a quiet mode which is disable by default.

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -36,6 +36,7 @@ DIFF_RANGE_NOTATION_HELP = (
 )
 QUIET_HELP = "Only print errors and failures"
 SHOW_UNCOVERED = "Show uncovered lines on the console"
+INCLUDE_UNTRACKED_HELP = "Include untracked files"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -120,6 +121,13 @@ def parse_coverage_args(argv):
     )
 
     parser.add_argument(
+        "--include-untracked",
+        action="store_true",
+        default=False,
+        help=INCLUDE_UNTRACKED_HELP,
+    )
+
+    parser.add_argument(
         "--exclude", metavar="EXCLUDE", type=str, nargs="+", help=EXCLUDE_HELP
     )
 
@@ -164,6 +172,7 @@ def generate_coverage_report(
     markdown_report=None,
     ignore_staged=False,
     ignore_unstaged=False,
+    include_untracked=False,
     exclude=None,
     src_roots=None,
     diff_range_notation=None,
@@ -179,6 +188,7 @@ def generate_coverage_report(
         git_diff=GitDiffTool(diff_range_notation, ignore_whitespace),
         ignore_staged=ignore_staged,
         ignore_unstaged=ignore_unstaged,
+        include_untracked=include_untracked,
         exclude=exclude,
     )
 
@@ -242,6 +252,7 @@ def main(argv=None, directory=None):
         css_file=arg_dict["external_css_file"],
         ignore_staged=arg_dict["ignore_staged"],
         ignore_unstaged=arg_dict["ignore_unstaged"],
+        include_untracked=arg_dict["include_untracked"],
         exclude=arg_dict["exclude"],
         src_roots=arg_dict["src_roots"],
         diff_range_notation=arg_dict["diff_range_notation"],

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -22,6 +22,7 @@ from diff_cover.diff_cover_tool import (
     IGNORE_STAGED_HELP,
     IGNORE_UNSTAGED_HELP,
     IGNORE_WHITESPACE,
+    INCLUDE_UNTRACKED_HELP,
     QUIET_HELP,
 )
 from diff_cover.diff_reporter import GitDiffReporter
@@ -142,6 +143,13 @@ def parse_quality_args(argv):
     )
 
     parser.add_argument(
+        "--include-untracked",
+        action="store_true",
+        default=False,
+        help=INCLUDE_UNTRACKED_HELP,
+    )
+
+    parser.add_argument(
         "--exclude", metavar="EXCLUDE", type=str, nargs="+", help=EXCLUDE_HELP
     )
 
@@ -181,6 +189,7 @@ def generate_quality_report(
     css_file=None,
     ignore_staged=False,
     ignore_unstaged=False,
+    include_untracked=False,
     exclude=None,
     include=None,
     diff_range_notation=None,
@@ -198,6 +207,7 @@ def generate_quality_report(
         git_diff=GitDiffTool(diff_range_notation, ignore_whitespace),
         ignore_staged=ignore_staged,
         ignore_unstaged=ignore_unstaged,
+        include_untracked=include_untracked,
         supported_extensions=supported_extensions,
         exclude=exclude,
         include=include,
@@ -286,6 +296,7 @@ def main(argv=None, directory=None):
                 css_file=arg_dict["external_css_file"],
                 ignore_staged=arg_dict["ignore_staged"],
                 ignore_unstaged=arg_dict["ignore_unstaged"],
+                include_untracked=arg_dict["include_untracked"],
                 exclude=arg_dict["exclude"],
                 include=arg_dict["include"],
                 diff_range_notation=arg_dict["diff_range_notation"],

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -112,6 +112,7 @@ class GitDiffReporter(BaseDiffReporter):
         git_diff=None,
         ignore_staged=None,
         ignore_unstaged=None,
+        include_untracked=False,
         supported_extensions=None,
         exclude=None,
         include=None,
@@ -142,6 +143,7 @@ class GitDiffReporter(BaseDiffReporter):
         self._git_diff_tool = git_diff
         self._ignore_staged = ignore_staged
         self._ignore_unstaged = ignore_unstaged
+        self._include_untracked = include_untracked
         self._supported_extensions = supported_extensions
 
         # Cache diff information as a dictionary
@@ -162,9 +164,12 @@ class GitDiffReporter(BaseDiffReporter):
         # Get the diff dictionary
         diff_dict = self._git_diff()
 
-        for path in self._git_diff_tool.git_untracked():
-            num_lines = sum(1 for _ in open(path))
-            diff_dict[path] = range(1, num_lines+1)
+        # include untracked files
+        if self._include_untracked:
+            for path in self._git_diff_tool.untracked():
+                with open(path) as file_handle:
+                    num_lines = sum(1 for _ in file_handle)
+                diff_dict[path] = range(1, num_lines + 1)
 
         # Return the changed file paths (dict keys)
         # in alphabetical order

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -170,7 +170,7 @@ class GitDiffReporter(BaseDiffReporter):
         if self._include_untracked:
             for path in self._git_diff_tool.untracked():
                 with open(path) as file_handle:
-                    num_lines = sum(1 for _ in file_handle)
+                    num_lines = len(file_handle.readlines())
                 diff_dict[path] = list(range(1, num_lines + 1))
 
         # Return the changed file paths (dict keys)

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -127,6 +127,8 @@ class GitDiffReporter(BaseDiffReporter):
             options.append("staged")
         if not ignore_unstaged:
             options.append("unstaged")
+        if include_untracked:
+            options.append("untracked")
 
         # Branch is always present, so use as basis for name
         name = f"{compare_branch}...HEAD"
@@ -169,7 +171,7 @@ class GitDiffReporter(BaseDiffReporter):
             for path in self._git_diff_tool.untracked():
                 with open(path) as file_handle:
                     num_lines = sum(1 for _ in file_handle)
-                diff_dict[path] = range(1, num_lines + 1)
+                diff_dict[path] = list(range(1, num_lines + 1))
 
         # Return the changed file paths (dict keys)
         # in alphabetical order

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -162,6 +162,10 @@ class GitDiffReporter(BaseDiffReporter):
         # Get the diff dictionary
         diff_dict = self._git_diff()
 
+        for path in self._git_diff_tool.git_untracked():
+            num_lines = sum(1 for _ in open(path))
+            diff_dict[path] = range(1, num_lines+1)
+
         # Return the changed file paths (dict keys)
         # in alphabetical order
         return sorted(diff_dict.keys(), key=lambda x: x.lower())

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -106,4 +106,5 @@ class GitDiffTool:
     def untracked(self):
         """Return the untracked files."""
         output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]
-        return output.strip().split("\n") if output else []
+        output = output.strip()
+        return output.split("\n") if output else []

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -102,3 +102,7 @@ class GitDiffTool:
         return execute(self._default_git_args + self._default_diff_args + ["--cached"])[
             0
         ]
+
+    def git_untracked(self):
+        output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]
+        return output.split("\n")[0:-1]

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -103,6 +103,7 @@ class GitDiffTool:
             0
         ]
 
-    def git_untracked(self):
+    def untracked(self):
+        """Return the untracked files."""
         output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]
-        return output.split("\n")[0:-1]
+        return output.strip().split("\n") if output else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,11 @@
 line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
-exclude = "diff_cover/tests/fixtures/*"
+exclude = "tests/fixtures/*"
 
 [tool.isort]
 profile = "black"
+extend_skip = "tests/fixtures/"
 
 [tool.pylint.master]
 max-line-length = 100

--- a/tests/test_git_diff.py
+++ b/tests/test_git_diff.py
@@ -181,3 +181,17 @@ def test_errors(set_git_diff_output, tool):
 
     with pytest.raises(CommandError):
         tool.diff_unstaged()
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("", []),
+        ("\n", []),
+        ("a.py\n", ["a.py"]),
+        ("a.py\nb.py\n", ["a.py", "b.py"]),
+    ],
+)
+def test_untracked(tool, set_git_diff_output, output, expected):
+    set_git_diff_output(output, b"")
+    assert tool.untracked() == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,8 +18,8 @@ from diff_cover.diff_cover_tool import main as diff_cover_main
 from diff_cover.diff_quality_tool import QUALITY_DRIVERS
 from diff_cover.diff_quality_tool import main as diff_quality_main
 from diff_cover.git_path import GitPathTool
-from tests.helpers import assert_long_str_equal, fixture_path
 from diff_cover.violationsreporters.base import QualityDriver
+from tests.helpers import assert_long_str_equal, fixture_path
 
 
 class ToolsIntegrationBase(unittest.TestCase):

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -13,11 +13,11 @@ from diff_cover.report_generator import (
     StringReportGenerator,
     TemplateReportGenerator,
 )
-from tests.helpers import assert_long_str_equal, load_fixture
 from diff_cover.violationsreporters.violations_reporter import (
     BaseViolationReporter,
     Violation,
 )
+from tests.helpers import assert_long_str_equal, load_fixture
 
 
 class SimpleReportGenerator(BaseReportGenerator):

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@ whitelist_externals =
 deps =
     -r{toxinidir}/test-requirements.txt
 commands =
-    black diff_cover
-    isort diff_cover
+    black diff_cover tests
+    isort diff_cover tests
     python -m pytest --cov --cov-report=xml tests
     git fetch origin main:refs/remotes/origin/main
-    diff-cover coverage.xml
+    diff-cover coverage.xml --include-untracked
     diff-quality --violation=flake8 --include-untracked
     diff-quality --violation=pylint --include-untracked

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ commands =
     python -m pytest --cov --cov-report=xml tests
     git fetch origin main:refs/remotes/origin/main
     diff-cover coverage.xml
-    diff-quality --violation=flake8
-    diff-quality --violation=pylint
+    diff-quality --violation=flake8 --include-untracked
+    diff-quality --violation=pylint --include-untracked

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ commands =
     python -m pytest --cov --cov-report=xml tests
     git fetch origin main:refs/remotes/origin/main
     diff-cover coverage.xml --include-untracked
-    diff-quality --violation=flake8 --include-untracked
-    diff-quality --violation=pylint --include-untracked
+    diff-quality --violations flake8 --include-untracked
+    diff-quality --violations pylint --include-untracked


### PR DESCRIPTION
Resolves #211

I fixed some issues with tox, black, isort as well: with the change to extracted tests, tox didn't run all tools correctly