### PR TITLE
Fix missing handling of windows newlines in pylint

### DIFF
--- a/diff_cover/util.py
+++ b/diff_cover/util.py
@@ -1,0 +1,17 @@
+import os.path
+import posixpath
+
+
+def to_unix_path(path):
+    """
+    Tries to ensure tha the path is a normalized unix path.
+    This seems to be the solution cobertura used....
+    https://github.com/cobertura/cobertura/blob/642a46eb17e14f51272c6962e64e56e0960918af/cobertura/src/main/java/net/sourceforge/cobertura/instrument/ClassPattern.java#L84
+
+    I know of at least one case where this will fail (\\) is allowed in unix paths.
+    But I am taking the bet that this is not common. We deal with source code.
+
+    :param path: string of the path to convert
+    :return: the unix version of that path
+    """
+    return posixpath.normpath(os.path.normcase(path).replace("\\", "/"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,13 @@
+import sys
+
+from diff_cover import util
+
+
+def test_to_unix_path():
+    """
+    Ensure the _to_unix_path static function handles paths properly.
+    """
+    assert util.to_unix_path("foo/bar") == "foo/bar"
+    assert util.to_unix_path("foo\\bar") == "foo/bar"
+    if sys.platform.startswith("win"):
+        assert util.to_unix_path("FOO\\bar") == "foo/bar"

--- a/tests/test_violations_reporter.py
+++ b/tests/test_violations_reporter.py
@@ -1,11 +1,10 @@
-# pylint: disable=missing-function-docstring,line-too-long,protected-access
+# pylint: disable=missing-function-docstring,line-too-long
 # pylint: disable=too-many-lines,attribute-defined-outside-init
 
 """Test for diff_cover.violations_reporter"""
 
 import os
 import subprocess
-import sys
 from io import BytesIO, StringIO
 
 try:
@@ -322,16 +321,6 @@ class TestXmlCoverageReporterTest:
                 line.set("number", str(line_num))
 
         return root
-
-    def test_to_unix_path(self):
-        """
-        Ensure the _to_unix_path static function handles paths properly.
-        """
-        to_unix_path = XmlCoverageReporter._to_unix_path
-        assert to_unix_path("foo/bar") == "foo/bar"
-        assert to_unix_path("foo\\bar") == "foo/bar"
-        if sys.platform.startswith("win"):
-            assert to_unix_path("FOO\\bar") == "foo/bar"
 
 
 class TestCloverXmlCoverageReporterTest:
@@ -1501,6 +1490,15 @@ class TestPylintQualityReporterTest:
 
         # Expect that the char is replaced
         assert violations == [Violation(2, "W1401: Invalid char '\ufffd'")]
+
+    def test_windows_paths(self, process_patcher):
+        process_patcher(
+            ("this\\is\\win.py:42: [C0111] Missing docstring", ""),
+            0,
+        )
+        quality = QualityReporter(PylintDriver())
+        violations = quality.violations("this/is/win.py")
+        assert violations == [Violation(42, "C0111: Missing docstring")]
 
 
 class JsQualityBaseReporterMixin:


### PR DESCRIPTION
Pylint might report paths with windows line endings.
Therefore this change moves the existing to_unix_path function into an own module to be reused.

Resolves #237 