### PR TITLE
Add tests directory to sdist tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,11 @@ packages = [
     { include = "diff_cover" }
 ]
 include = [
-    "templates/*.txt",
-    "templates/*.html",
-    "templates/*.css",
-    "templates/*.md"
+    {path = 'templates/*.txt'},
+    {path = 'templates/*.html'},
+    {path = 'templates/*.css'},
+    {path = 'templates/*.md'},
+    {path = 'tests/*', format = 'sdist'},
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
pyproject.toml:
Change `tool.poetry.include` to include the tests directory recursively
for the sdist format.

Fixes #251

Signed-off-by: David Runge <dave@sleepmap.de>