### PR TITLE
Fix overseen CLI default

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -164,7 +164,7 @@ def parse_coverage_args(argv):
     defaults = {
         "show_uncovered": False,
         "compare_branch": "origin/main",
-        "fail_under": "0",
+        "fail_under": 0,
         "ignore_staged": False,
         "ignore_unstaged": False,
         "ignore_untracked": False,

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -103,7 +103,7 @@ def parse_coverage_args(argv):
     )
 
     parser.add_argument(
-        "--fail-under", metavar="SCORE", type=float, default="0", help=FAIL_UNDER_HELP
+        "--fail-under", metavar="SCORE", type=float, default=None, help=FAIL_UNDER_HELP
     )
 
     parser.add_argument(


### PR DESCRIPTION
As TOML config file support was added, all default values of the CLI must be None and be moved to a default dict.
This was forgotten for fail-under.