### PR TITLE
Fix/All affected lines are reportable

### DIFF
--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -235,7 +235,9 @@ class GitDiffReporter(BaseDiffReporter):
                         or extension in self._supported_extensions
                     ):
                         # All affected lines are reportable
-                        result_dict[src_path] = result_dict.get(src_path, []) + added_lines + deleted_lines
+                        result_dict[src_path] = (
+                            result_dict.get(src_path, []) + added_lines + deleted_lines
+                        )
 
             # Eliminate repeats and order line numbers
             for (src_path, lines) in result_dict.items():

--- a/diff_cover/diff_reporter.py
+++ b/diff_cover/diff_reporter.py
@@ -234,13 +234,8 @@ class GitDiffReporter(BaseDiffReporter):
                         not self._supported_extensions
                         or extension in self._supported_extensions
                     ):
-                        # Remove any lines from the dict that have been deleted
-                        # Include any lines that have been added
-                        result_dict[src_path] = [
-                            line
-                            for line in result_dict.get(src_path, [])
-                            if line not in deleted_lines
-                        ] + added_lines
+                        # All affected lines are reportable
+                        result_dict[src_path] = result_dict.get(src_path, []) + added_lines + deleted_lines
 
             # Eliminate repeats and order line numbers
             for (src_path, lines) in result_dict.items():


### PR DESCRIPTION
If lines are deleted it doesn't mean there's nothing in their place. In fact because these lines were deleted, the code below the deleted part is now in their place, taking those line numbers that are reported by git diff as deleted. The fact that there's something is reflected in the coverage report. 

In other words, if certain lines are in the coverage report marked as not covered by tests, and those same line numbers are in the git diff marked as deleted, it necessarily means that "something else" took the place of the deleted part. And that "something else" is the code that was below the deleted part.