### PR TITLE
Fix test_style_defs

### DIFF
--- a/tests/fixtures/snippet.css
+++ b/tests/fixtures/snippet.css
@@ -1,8 +1,8 @@
 .hll { background-color: #ffcccc }
-.c { color: #408080; font-style: italic } /* Comment */
+.c { color: #3D7B7B; font-style: italic } /* Comment */
 .k { color: #008000; font-weight: bold } /* Keyword */
 .o { color: #666666 } /* Operator */
 .m { color: #666666 } /* Literal.Number */
 .s { color: #BA2121 } /* Literal.String */
-.na { color: #7D9029 } /* Name.Attribute */
+.na { color: #687822 } /* Name.Attribute */
 .nb { color: #008000 } /* Name.Builtin */


### PR DESCRIPTION
The pygments module made a change to default snippet styles in 2.11.0,
    which breaks the test_style_defs unit here using predefined styles
    from old pygments.
See https://github.com/pygments/pygments/pull/1940 for more information.
This resolves https://github.com/Bachmann1234/diff_cover/issues/266.