### PR TITLE
Update HTML fixtures for pygment 2.12.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -326,11 +326,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.11.2"
+version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pylint"
@@ -675,12 +675,28 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -689,14 +705,27 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -706,6 +735,12 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -755,8 +790,8 @@ pyflakes = [
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pygments = [
-    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
-    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
+    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
 ]
 pylint = [
     {file = "pylint-2.12.2-py3-none-any.whl", hash = "sha256:daabda3f7ed9d1c60f52d563b1b854632fd90035bcf01443e234d3dc794e3b74"},

--- a/tests/fixtures/pycodestyle_violations_report_external_css.html
+++ b/tests/fixtures/pycodestyle_violations_report_external_css.html
@@ -35,7 +35,7 @@
         <div class="src-snippet">
             <div class="src-name">violations_test_file.py</div>
             <div class="snippets">
-            <table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 1</span>
+            <div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 1</span>
 <span class="normal"> 2</span>
 <span class="normal"> 3</span>
 <span class="normal"> 4</span>
@@ -46,7 +46,7 @@
 <span class="normal"> 9</span>
 <span class="normal">10</span>
 <span class="normal">11</span>
-<span class="normal">12</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="violations_test_file.py-1" name="violations_test_file.py-1"></a><span class="k">def</span> <span class="nf">func_1</span><span class="p">(</span><span class="n">apple</span><span class="p">,</span> <span class="n">my_list</span><span class="p">):</span>
+<span class="normal">12</span></pre></div></td><td class="code"><div><pre><span></span><a id="violations_test_file.py-1" name="violations_test_file.py-1"></a><span class="k">def</span> <span class="nf">func_1</span><span class="p">(</span><span class="n">apple</span><span class="p">,</span> <span class="n">my_list</span><span class="p">):</span>
 <a id="violations_test_file.py-2" name="violations_test_file.py-2"></a><span class="hll">    <span class="k">if</span> <span class="n">apple</span><span class="o">&lt;</span><span class="mi">10</span><span class="p">:</span>
 </span><a id="violations_test_file.py-3" name="violations_test_file.py-3"></a>        <span class="c1"># Do something </span>
 <a id="violations_test_file.py-4" name="violations_test_file.py-4"></a>        <span class="n">my_list</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">apple</span><span class="p">)</span>
@@ -58,8 +58,7 @@
 <a id="violations_test_file.py-10" name="violations_test_file.py-10"></a>            <span class="k">return</span> <span class="n">char</span>
 <a id="violations_test_file.py-11" name="violations_test_file.py-11"></a><span class="hll">    <span class="n">unused</span><span class="o">=</span><span class="mi">1</span>
 </span><a id="violations_test_file.py-12" name="violations_test_file.py-12"></a>    <span class="k">return</span> <span class="kc">None</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>
             </div>
         </div>
     </body>

--- a/tests/fixtures/snippet_arabic_output.html
+++ b/tests/fixtures/snippet_arabic_output.html
@@ -1,11 +1,11 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 3</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 3</span>
 <span class="normal"> 4</span>
 <span class="normal"> 5</span>
 <span class="normal"> 6</span>
 <span class="normal"> 7</span>
 <span class="normal"> 8</span>
 <span class="normal"> 9</span>
-<span class="normal">10</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="snippet_8859.py-3" name="snippet_8859.py-3"></a><span class="n">Line</span> <span class="mi">3</span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><a id="snippet_8859.py-3" name="snippet_8859.py-3"></a><span class="n">Line</span> <span class="mi">3</span>
 <a id="snippet_8859.py-4" name="snippet_8859.py-4"></a><span class="n">Line</span> <span class="mi">4</span>
 <a id="snippet_8859.py-5" name="snippet_8859.py-5"></a><span class="n">Line</span> <span class="mi">5</span>
 <a id="snippet_8859.py-6" name="snippet_8859.py-6"></a><span class="n">Line</span> <span class="mi">6</span>
@@ -13,5 +13,4 @@
 </span><a id="snippet_8859.py-8" name="snippet_8859.py-8"></a><span class="n">Line</span> <span class="mi">8</span>
 <a id="snippet_8859.py-9" name="snippet_8859.py-9"></a><span class="n">Line</span> <span class="mi">9</span>
 <a id="snippet_8859.py-10" name="snippet_8859.py-10"></a><span class="n">Line</span> <span class="mi">10</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_default.html
+++ b/tests/fixtures/snippet_default.html
@@ -1,9 +1,8 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">4</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">4</span>
 <span class="normal">5</span>
 <span class="normal">6</span>
-<span class="normal">7</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="test.py-4" name="test.py-4"></a><span class="hll"><span class="c"># Test source</span>
+<span class="normal">7</span></pre></div></td><td class="code"><div><pre><span></span><a id="test.py-4" name="test.py-4"></a><span class="hll"><span class="c"># Test source</span>
 </span><a id="test.py-5" name="test.py-5"></a><span class="k">def</span> <span class="nf">test_func</span><span class="p">(</span><span class="n">arg</span><span class="p">):</span>
 <a id="test.py-6" name="test.py-6"></a><span class="hll">    <span class="k">print</span> <span class="n">arg</span>
 </span><a id="test.py-7" name="test.py-7"></a>    <span class="k">return</span> <span class="n">arg</span> <span class="o">+</span> <span class="mi">5</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_invalid_violations.html
+++ b/tests/fixtures/snippet_invalid_violations.html
@@ -1,9 +1,8 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
 <span class="normal">3</span>
-<span class="normal">4</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="test.py-1" name="test.py-1"></a><span class="c"># Test source</span>
+<span class="normal">4</span></pre></div></td><td class="code"><div><pre><span></span><a id="test.py-1" name="test.py-1"></a><span class="c"># Test source</span>
 <a id="test.py-2" name="test.py-2"></a><span class="k">def</span> <span class="nf">test_func</span><span class="p">(</span><span class="n">arg</span><span class="p">):</span>
 <a id="test.py-3" name="test.py-3"></a>    <span class="k">print</span> <span class="n">arg</span>
 <a id="test.py-4" name="test.py-4"></a>    <span class="k">return</span> <span class="n">arg</span> <span class="o">+</span> <span class="mi">5</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_list.html
+++ b/tests/fixtures/snippet_list.html
@@ -1,4 +1,4 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 6</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 6</span>
 <span class="normal"> 7</span>
 <span class="normal"> 8</span>
 <span class="normal"> 9</span>
@@ -9,7 +9,7 @@
 <span class="normal">14</span>
 <span class="normal">15</span>
 <span class="normal">16</span>
-<span class="normal">17</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="snippet_src.py-6" name="snippet_src.py-6"></a><span class="n">Line</span> <span class="mi">6</span>
+<span class="normal">17</span></pre></div></td><td class="code"><div><pre><span></span><a id="snippet_src.py-6" name="snippet_src.py-6"></a><span class="n">Line</span> <span class="mi">6</span>
 <a id="snippet_src.py-7" name="snippet_src.py-7"></a><span class="n">Line</span> <span class="mi">7</span>
 <a id="snippet_src.py-8" name="snippet_src.py-8"></a><span class="n">Line</span> <span class="mi">8</span>
 <a id="snippet_src.py-9" name="snippet_src.py-9"></a><span class="n">Line</span> <span class="mi">9</span>
@@ -21,10 +21,10 @@
 <a id="snippet_src.py-15" name="snippet_src.py-15"></a><span class="n">Line</span> <span class="mi">15</span>
 <a id="snippet_src.py-16" name="snippet_src.py-16"></a><span class="n">Line</span> <span class="mi">16</span>
 <a id="snippet_src.py-17" name="snippet_src.py-17"></a><span class="n">Line</span> <span class="mi">17</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>
 
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">46</span>
+
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">46</span>
 <span class="normal">47</span>
 <span class="normal">48</span>
 <span class="normal">49</span>
@@ -39,7 +39,7 @@
 <span class="normal">58</span>
 <span class="normal">59</span>
 <span class="normal">60</span>
-<span class="normal">61</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="snippet_src.py-46" name="snippet_src.py-46"></a><span class="n">Line</span> <span class="mi">46</span>
+<span class="normal">61</span></pre></div></td><td class="code"><div><pre><span></span><a id="snippet_src.py-46" name="snippet_src.py-46"></a><span class="n">Line</span> <span class="mi">46</span>
 <a id="snippet_src.py-47" name="snippet_src.py-47"></a><span class="n">Line</span> <span class="mi">47</span>
 <a id="snippet_src.py-48" name="snippet_src.py-48"></a><span class="n">Line</span> <span class="mi">48</span>
 <a id="snippet_src.py-49" name="snippet_src.py-49"></a><span class="n">Line</span> <span class="mi">49</span>
@@ -55,5 +55,4 @@
 <a id="snippet_src.py-59" name="snippet_src.py-59"></a><span class="n">Line</span> <span class="mi">59</span>
 <a id="snippet_src.py-60" name="snippet_src.py-60"></a><span class="n">Line</span> <span class="mi">60</span>
 <a id="snippet_src.py-61" name="snippet_src.py-61"></a><span class="n">Line</span> <span class="mi">61</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_no_filename_ext.html
+++ b/tests/fixtures/snippet_no_filename_ext.html
@@ -1,9 +1,8 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">4</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">4</span>
 <span class="normal">5</span>
 <span class="normal">6</span>
-<span class="normal">7</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="test-4" name="test-4"></a><span class="hll"><span class="c"># Test source</span>
+<span class="normal">7</span></pre></div></td><td class="code"><div><pre><span></span><a id="test-4" name="test-4"></a><span class="hll"><span class="c"># Test source</span>
 </span><a id="test-5" name="test-5"></a><span class="k">def</span> <span class="nf">test_func</span><span class="p">(</span><span class="n">arg</span><span class="p">):</span>
 <a id="test-6" name="test-6"></a><span class="hll">    <span class="k">print</span> <span class="n">arg</span>
 </span><a id="test-7" name="test-7"></a>    <span class="k">return</span> <span class="n">arg</span> <span class="o">+</span> <span class="mi">5</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_unicode.html
+++ b/tests/fixtures/snippet_unicode.html
@@ -1,3 +1,2 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="test.py-1" name="test.py-1"></a>var = ģ 塲 ㎉
-</pre></div>
-</td></tr></table>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span></pre></div></td><td class="code"><div><pre><span></span><a id="test.py-1" name="test.py-1"></a>var = ģ 塲 ㎉
+</pre></div></td></tr></table></div>

--- a/tests/fixtures/snippet_unicode_html_output.html
+++ b/tests/fixtures/snippet_unicode_html_output.html
@@ -1,4 +1,4 @@
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 6</span>
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 6</span>
 <span class="normal"> 7</span>
 <span class="normal"> 8</span>
 <span class="normal"> 9</span>
@@ -9,7 +9,7 @@
 <span class="normal">14</span>
 <span class="normal">15</span>
 <span class="normal">16</span>
-<span class="normal">17</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="snippet_unicode.py-6" name="snippet_unicode.py-6"></a><span class="n">Line</span> <span class="mi">6</span>
+<span class="normal">17</span></pre></div></td><td class="code"><div><pre><span></span><a id="snippet_unicode.py-6" name="snippet_unicode.py-6"></a><span class="n">Line</span> <span class="mi">6</span>
 <a id="snippet_unicode.py-7" name="snippet_unicode.py-7"></a><span class="n">Line</span> <span class="mi">7</span>
 <a id="snippet_unicode.py-8" name="snippet_unicode.py-8"></a><span class="n">Line</span> <span class="mi">8</span>
 <a id="snippet_unicode.py-9" name="snippet_unicode.py-9"></a><span class="n">Line</span> <span class="mi">9</span>
@@ -21,10 +21,10 @@
 <a id="snippet_unicode.py-15" name="snippet_unicode.py-15"></a><span class="n">Line</span> <span class="mi">15</span>
 <a id="snippet_unicode.py-16" name="snippet_unicode.py-16"></a><span class="n">Line</span> <span class="mi">16</span>
 <a id="snippet_unicode.py-17" name="snippet_unicode.py-17"></a><span class="n">Line</span> <span class="mi">17</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>
 
-<table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">46</span>
+
+<div class="snippet"><table class="snippettable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">46</span>
 <span class="normal">47</span>
 <span class="normal">48</span>
 <span class="normal">49</span>
@@ -39,7 +39,7 @@
 <span class="normal">58</span>
 <span class="normal">59</span>
 <span class="normal">60</span>
-<span class="normal">61</span></pre></div></td><td class="code"><div class="snippet"><pre><span></span><a id="snippet_unicode.py-46" name="snippet_unicode.py-46"></a><span class="n">Line</span> <span class="mi">46</span>
+<span class="normal">61</span></pre></div></td><td class="code"><div><pre><span></span><a id="snippet_unicode.py-46" name="snippet_unicode.py-46"></a><span class="n">Line</span> <span class="mi">46</span>
 <a id="snippet_unicode.py-47" name="snippet_unicode.py-47"></a><span class="n">Line</span> <span class="mi">47</span>
 <a id="snippet_unicode.py-48" name="snippet_unicode.py-48"></a><span class="n">Line</span> <span class="mi">48</span>
 <a id="snippet_unicode.py-49" name="snippet_unicode.py-49"></a><span class="n">Line</span> <span class="mi">49</span>
@@ -55,5 +55,4 @@
 <a id="snippet_unicode.py-59" name="snippet_unicode.py-59"></a><span class="n">Line</span> <span class="mi">59</span>
 <a id="snippet_unicode.py-60" name="snippet_unicode.py-60"></a><span class="n">Line</span> <span class="mi">60</span>
 <a id="snippet_unicode.py-61" name="snippet_unicode.py-61"></a><span class="n">Line</span> <span class="mi">61</span>
-</pre></div>
-</td></tr></table>
+</pre></div></td></tr></table></div>


### PR DESCRIPTION
pygment 2.12.0 slightly changes HTML output when `linenos=table`
is used:

"When ``linenos=table`` is used, the ``<table>`` itself is now
wrapped with a ``<div class="highlight">`` tag instead of placing
it inside the ``<td class="code">`` cell (#632.) With this change,
the output matches the documented behavior."

That affects several of the HTML fixtures used in the snippets
tests. This updates them to match pygment's new format. Of
course, this means the tests now only pass with pygment 2.12.0
or higher.

Signed-off-by: Adam Williamson <awilliam@redhat.com>