### PR TITLE
fix: diff-cover breaks when there's branch coverage information in lc…

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -316,6 +316,7 @@ class LcovCoverageReporter(BaseViolationReporter):
                 "LF",
                 "BRF",
                 "BRH",
+                "BRDA",
             ]:
                 # these are valid lines, but not we don't need them
                 continue

--- a/tests/fixtures/lcov.info
+++ b/tests/fixtures/lcov.info
@@ -20,4 +20,5 @@ LF:6
 LH:6
 BRF:0
 BRH:0
+BRDA:3,0,0,0
 end_of_record


### PR DESCRIPTION
I've missed the BRDA lines in the lcov.info in the original PR.

ref: https://ltp.sourceforge.net/coverage/lcov/geninfo.1.php
