### PR TITLE
Need to move back to the original directory before cleaning up the tempdir

### DIFF
--- a/tests/test_diff_reporter.py
+++ b/tests/test_diff_reporter.py
@@ -135,8 +135,8 @@ def test_git_path_selection(diff, git_diff, include, exclude, expected):
         # They should be in alphabetical order
         assert source_paths == expected
 
-    # change back to the previous working directory
-    os.chdir(old_cwd)
+        # change back to the previous working directory
+        os.chdir(old_cwd)
 
 
 def test_git_source_paths(diff, git_diff):

--- a/tests/test_diff_reporter.py
+++ b/tests/test_diff_reporter.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 
@@ -96,7 +97,7 @@ def test_name_include_untracked(git_diff):
         ),
     ],
 )
-def test_git_path_selection(mocker, diff, git_diff, include, exclude, expected):
+def test_git_path_selection(diff, git_diff, include, exclude, expected):
     old_cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as tmp_dir:
         # change the working directory into the temp directory so that globs are working
@@ -127,8 +128,8 @@ def test_git_path_selection(mocker, diff, git_diff, include, exclude, expected):
         )
 
         # Get the source paths in the diff
-        mocker.patch.object(os.path, "abspath", lambda path: f"{tmp_dir}/{path}")
-        source_paths = diff.src_paths_changed()
+        with patch.object(os.path, "abspath", lambda path: f"{tmp_dir}/{path}"):
+            source_paths = diff.src_paths_changed()
 
         # Validate the source paths
         # They should be in alphabetical order


### PR DESCRIPTION
This switches from `mocker` to vanilla patch as a context decorator. 

Also handles moving out the the temporary decorator *before* that context manager cleans up said tempdir. This ensures the test passes in platforms that are unable to delete the directory you are currently inside of. (Solaris)