### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+- id: run-diff-cover
+  name: run-diff-cover
+  description: This will compare the current git branch to origin/main and print the diff coverage report to the console.
+  entry: diff-cover
+  args: ['coverage.xml', '--fail-under=80', '-q']
+  stages: [commit]
+  language: python
+  language_version: python3
+  pass_filenames: false
+
+- id: run-diff-quality
+  name: run-diff-quality
+  description: This will compare the current git branch to origin/main and print the quality coverage report to the console.
+  entry: diff-quality
+  args: ['--violations=pycodestyle', '--fail-under=80', '-q']
+  stages: [commit]
+  language: python
+  language_version: python3
+  pass_filenames: false

--- a/README.rst
+++ b/README.rst
@@ -280,6 +280,25 @@ If an option can be specified multiple times, the configuration value should be 
     compare_branch = "origin/feature"
     ignore_staged = true
 
+Integrating with Pre-commit
+----------------------
+Use pre-commit. Once you have it installed, add this to the ``.pre-commit-config.yaml`` in your repository:
+
+.. code:: yaml
+
+    repos:
+      - repo: https://github.com/psf/black
+        rev: 'main'
+        hooks:
+          - id: run-diff-cover
+            # You can add args here
+            # args: ['coverage.xml', '--fail-under=80', '-q']
+          - id: run-diff-quality
+            # You can add args here
+            # args: ['--violations=pycodestyle', '--fail-under=80', '-q']
+
+
+Feel free to switch out the rev value to something else, like another tag/version or even a specific commit.
 
 Troubleshooting
 ----------------------


### PR DESCRIPTION
Add `.pre-commit-hooks.yaml` file.
Add integration of Pre-commit in README.
pre-commit is A framework for managing and maintaining multi-language pre-commit hooks. add `.pre-commit-hooks.yaml` makes it easier to use the git hook.