### PR TITLE
Normalise LCOV source paths

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -297,7 +297,7 @@ class LcovCoverageReporter(BaseViolationReporter):
             # we're only interested in file name and line coverage
             if directive == "SF":
                 # SF:<absolute path to the source file>
-                source_file = content
+                source_file = util.to_unix_path(GitPathTool.relative_path(content))
                 continue
             elif directive == "DA":
                 # DA:<line number>,<execution count>[,<checksum>]


### PR DESCRIPTION
Under windows, the git paths use unix-style paths, while the lcov paths use windows-style paths. In addition, coverage.py uses relative paths, but other tools like llvm-cov report absolute paths. So the source paths need to be made relative and unix-style.

I've tested this on Windows, before this fix I get `No lines with coverage information in this diff.` while afterwards the tool reports coverage changes correctly.