### PR TITLE
Added option to specify diff file location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,33 @@ By default, ``diff-cover`` compares the current branch to ``origin/main``.  To s
 
     diff-cover coverage.xml --compare-branch=origin/release
 
+Diff File
+--------------
+
+You may provide a file containing the output of ``git diff`` to ``diff-cover`` instead of using a branch name.
+
+For example, Say you have 2 branches ``main`` and ``feature``. Lets say after creating and checking out the feature branch,
+you make commits ``A``, ``B``, and ``C`` in that order.
+
+
+If you want to see all changes between the ``feature`` and ``main`` branch, you can generate a diff file like this:
+
+.. code:: bash
+
+    git diff main..feature > diff.txt
+
+If you want to see the changes between the ``feature`` branch and the commit ``A``, you can generate a diff file using the following command:
+
+.. code:: bash
+
+    git diff A..feature > diff.txt
+
+You can then run ``diff-cover`` with the diff file as an argument:
+
+.. code:: bash
+
+    diff-cover coverage.xml --diff-file=diff.txt
+
 Fail Under
 ----------
 

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -170,10 +170,8 @@ def parse_coverage_args(argv):
         "-c", "--config-file", help=CONFIG_FILE_HELP, metavar="CONFIG_FILE"
     )
 
-    parser.add_argument(
-        "--diff-file", type=str, default=None, help=DIFF_FILE_HELP
-    )
-    
+    parser.add_argument("--diff-file", type=str, default=None, help=DIFF_FILE_HELP)
+
     defaults = {
         "show_uncovered": False,
         "compare_branch": "origin/main",
@@ -288,7 +286,9 @@ def main(argv=None, directory=None):
     diff_tool = None
 
     if not arg_dict["diff_file"]:
-        diff_tool = GitDiffTool(arg_dict["diff_range_notation"], arg_dict["ignore_whitespace"])
+        diff_tool = GitDiffTool(
+            arg_dict["diff_range_notation"], arg_dict["ignore_whitespace"]
+        )
     else:
         diff_tool = GitDiffFileTool(arg_dict["diff_file"])
 

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as etree
 from diff_cover import DESCRIPTION, VERSION
 from diff_cover.config_parser import Tool, get_config
 from diff_cover.diff_reporter import GitDiffReporter
-from diff_cover.git_diff import GitDiffTool, GitDiffFileTool
+from diff_cover.git_diff import GitDiffFileTool, GitDiffTool
 from diff_cover.git_path import GitPathTool
 from diff_cover.report_generator import (
     HtmlReportGenerator,

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as etree
 from diff_cover import DESCRIPTION, VERSION
 from diff_cover.config_parser import Tool, get_config
 from diff_cover.diff_reporter import GitDiffReporter
-from diff_cover.git_diff import GitDiffTool
+from diff_cover.git_diff import GitDiffTool, GitDiffFileTool
 from diff_cover.git_path import GitPathTool
 from diff_cover.report_generator import (
     HtmlReportGenerator,
@@ -43,6 +43,7 @@ QUIET_HELP = "Only print errors and failures"
 SHOW_UNCOVERED = "Show uncovered lines on the console"
 INCLUDE_UNTRACKED_HELP = "Include untracked files"
 CONFIG_FILE_HELP = "The configuration file to use"
+DIFF_FILE_HELP = "The diff file to use"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -169,6 +170,10 @@ def parse_coverage_args(argv):
         "-c", "--config-file", help=CONFIG_FILE_HELP, metavar="CONFIG_FILE"
     )
 
+    parser.add_argument(
+        "--diff-file", type=str, default=None, help=DIFF_FILE_HELP
+    )
+    
     defaults = {
         "show_uncovered": False,
         "compare_branch": "origin/main",
@@ -188,6 +193,7 @@ def parse_coverage_args(argv):
 def generate_coverage_report(
     coverage_files,
     compare_branch,
+    diff_tool,
     html_report=None,
     css_file=None,
     json_report=None,
@@ -198,8 +204,6 @@ def generate_coverage_report(
     exclude=None,
     include=None,
     src_roots=None,
-    diff_range_notation=None,
-    ignore_whitespace=False,
     quiet=False,
     show_uncovered=False,
 ):
@@ -208,7 +212,7 @@ def generate_coverage_report(
     """
     diff = GitDiffReporter(
         compare_branch,
-        git_diff=GitDiffTool(diff_range_notation, ignore_whitespace),
+        git_diff=diff_tool,
         ignore_staged=ignore_staged,
         ignore_unstaged=ignore_unstaged,
         include_untracked=include_untracked,
@@ -281,9 +285,17 @@ def main(argv=None, directory=None):
 
     GitPathTool.set_cwd(directory)
     fail_under = arg_dict.get("fail_under")
+    diff_tool = None
+
+    if not arg_dict["diff_file"]:
+        diff_tool = GitDiffTool(arg_dict["diff_range_notation"], arg_dict["ignore_whitespace"])
+    else:
+        diff_tool = GitDiffFileTool(arg_dict["diff_file"])
+
     percent_covered = generate_coverage_report(
         arg_dict["coverage_file"],
         arg_dict["compare_branch"],
+        diff_tool,
         html_report=arg_dict["html_report"],
         json_report=arg_dict["json_report"],
         markdown_report=arg_dict["markdown_report"],
@@ -294,8 +306,6 @@ def main(argv=None, directory=None):
         exclude=arg_dict["exclude"],
         include=arg_dict["include"],
         src_roots=arg_dict["src_roots"],
-        diff_range_notation=arg_dict["diff_range_notation"],
-        ignore_whitespace=arg_dict["ignore_whitespace"],
         quiet=quiet,
         show_uncovered=arg_dict["show_uncovered"],
     )

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -111,13 +111,14 @@ class GitDiffTool:
             return []
         return [line for line in output.splitlines() if line]
 
+
 class GitDiffFileTool(GitDiffTool):
 
     def __init__(self, diff_file_path):
 
         self.diff_file_path = diff_file_path
         super().__init__("...", False)
-        
+
     def diff_committed(self, compare_branch="origin/main"):
         """
         Returns the contents of a diff file.
@@ -125,7 +126,7 @@ class GitDiffFileTool(GitDiffTool):
         Raises a `GitDiffError` if the file cannot be read.
         """
         try:
-            with open(self.diff_file_path, 'r') as file:
+            with open(self.diff_file_path, "r") as file:
                 return file.read()
         except IOError as e:
             raise ValueError(
@@ -133,14 +134,14 @@ class GitDiffFileTool(GitDiffTool):
                     f"""
                     Could not read the diff file. Make sure '{self.diff_file_path}' exists?
                     """
-                    )
                 )
-        
+            )
+
     def diff_unstaged(self):
         return ""
-    
+
     def diff_staged(self):
         return ""
-    
+
     def untracked(self):
         return ""

--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -110,3 +110,37 @@ class GitDiffTool:
         if not output:
             return []
         return [line for line in output.splitlines() if line]
+
+class GitDiffFileTool(GitDiffTool):
+
+    def __init__(self, diff_file_path):
+
+        self.diff_file_path = diff_file_path
+        super().__init__("...", False)
+        
+    def diff_committed(self, compare_branch="origin/main"):
+        """
+        Returns the contents of a diff file.
+
+        Raises a `GitDiffError` if the file cannot be read.
+        """
+        try:
+            with open(self.diff_file_path, 'r') as file:
+                return file.read()
+        except IOError as e:
+            raise ValueError(
+                dedent(
+                    f"""
+                    Could not read the diff file. Make sure '{self.diff_file_path}' exists?
+                    """
+                    )
+                )
+        
+    def diff_unstaged(self):
+        return ""
+    
+    def diff_staged(self):
+        return ""
+    
+    def untracked(self):
+        return ""

--- a/tests/test_git_diff_file.py
+++ b/tests/test_git_diff_file.py
@@ -6,56 +6,67 @@ import pytest
 
 from diff_cover.git_diff import GitDiffFileTool
 
+
 @pytest.fixture
 def mock_file(mocker):
     def _inner(file_content):
         mock_open = mocker.mock_open(read_data=file_content)
-        mocker.patch('builtins.open', mock_open)
+        mocker.patch("builtins.open", mock_open)
+
     return _inner
+
 
 @pytest.fixture
 def diff_tool():
     def _inner(file):
         return GitDiffFileTool(file)
+
     return _inner
 
-def test_diff_file_not_found(mocker, diff_tool):
-    mocker.patch('builtins.open', side_effect=IOError)
 
-    _diff_tool = diff_tool('non_existent_diff_file.txt')
+def test_diff_file_not_found(mocker, diff_tool):
+    mocker.patch("builtins.open", side_effect=IOError)
+
+    _diff_tool = diff_tool("non_existent_diff_file.txt")
 
     with pytest.raises(ValueError) as excinfo:
         _diff_tool.diff_committed()
 
-    assert f"Could not read the diff file. Make sure '{_diff_tool.diff_file_path}' exists?" in str(excinfo.value)
-    assert _diff_tool.diff_file_path == 'non_existent_diff_file.txt'
+    assert (
+        f"Could not read the diff file. Make sure '{_diff_tool.diff_file_path}' exists?"
+        in str(excinfo.value)
+    )
+    assert _diff_tool.diff_file_path == "non_existent_diff_file.txt"
+
 
 def test_large_diff_file(mock_file, diff_tool):
-    large_diff = 'diff --git a/file1 b/file2\n' * 1000000
+    large_diff = "diff --git a/file1 b/file2\n" * 1000000
 
     mock_file(large_diff)
 
-    _diff_tool = diff_tool('large_diff_file.txt')
+    _diff_tool = diff_tool("large_diff_file.txt")
 
     assert _diff_tool.diff_committed() == large_diff
-    assert _diff_tool.diff_file_path == 'large_diff_file.txt'
+    assert _diff_tool.diff_file_path == "large_diff_file.txt"
+
 
 def test_diff_committed(mock_file, diff_tool):
-    diff = 'diff --git a/file1 b/file2\n'
+    diff = "diff --git a/file1 b/file2\n"
 
     mock_file(diff)
 
-    _diff_tool = diff_tool('diff_file.txt')
+    _diff_tool = diff_tool("diff_file.txt")
 
     assert _diff_tool.diff_committed() == diff
-    assert _diff_tool.diff_file_path == 'diff_file.txt'
+    assert _diff_tool.diff_file_path == "diff_file.txt"
+
 
 def test_empty_diff_file(mock_file, diff_tool):
-    empty_diff = ''
+    empty_diff = ""
 
     mock_file(empty_diff)
-    
-    _diff_tool = diff_tool('empty_diff.txt')
+
+    _diff_tool = diff_tool("empty_diff.txt")
 
     assert _diff_tool.diff_committed() == empty_diff
-    assert _diff_tool.diff_file_path == 'empty_diff.txt'
+    assert _diff_tool.diff_file_path == "empty_diff.txt"

--- a/tests/test_git_diff_file.py
+++ b/tests/test_git_diff_file.py
@@ -1,0 +1,61 @@
+# pylint: disable=missing-function-docstring
+
+"""Test for diff_cover.git_diff.GitDiffFileTool"""
+
+import pytest
+
+from diff_cover.git_diff import GitDiffFileTool
+
+@pytest.fixture
+def mock_file(mocker):
+    def _inner(file_content):
+        mock_open = mocker.mock_open(read_data=file_content)
+        mocker.patch('builtins.open', mock_open)
+    return _inner
+
+@pytest.fixture
+def diff_tool():
+    def _inner(file):
+        return GitDiffFileTool(file)
+    return _inner
+
+def test_diff_file_not_found(mocker, diff_tool):
+    mocker.patch('builtins.open', side_effect=IOError)
+
+    _diff_tool = diff_tool('non_existent_diff_file.txt')
+
+    with pytest.raises(ValueError) as excinfo:
+        _diff_tool.diff_committed()
+
+    assert f"Could not read the diff file. Make sure '{_diff_tool.diff_file_path}' exists?" in str(excinfo.value)
+    assert _diff_tool.diff_file_path == 'non_existent_diff_file.txt'
+
+def test_large_diff_file(mock_file, diff_tool):
+    large_diff = 'diff --git a/file1 b/file2\n' * 1000000
+
+    mock_file(large_diff)
+
+    _diff_tool = diff_tool('large_diff_file.txt')
+
+    assert _diff_tool.diff_committed() == large_diff
+    assert _diff_tool.diff_file_path == 'large_diff_file.txt'
+
+def test_diff_committed(mock_file, diff_tool):
+    diff = 'diff --git a/file1 b/file2\n'
+
+    mock_file(diff)
+
+    _diff_tool = diff_tool('diff_file.txt')
+
+    assert _diff_tool.diff_committed() == diff
+    assert _diff_tool.diff_file_path == 'diff_file.txt'
+
+def test_empty_diff_file(mock_file, diff_tool):
+    empty_diff = ''
+
+    mock_file(empty_diff)
+    
+    _diff_tool = diff_tool('empty_diff.txt')
+
+    assert _diff_tool.diff_committed() == empty_diff
+    assert _diff_tool.diff_file_path == 'empty_diff.txt'


### PR DESCRIPTION
Added a flag to accept a path which points to a file containing the output of `git diff`

ex: `diff-cover coverage_folder/coverage.xml --html-report report.html --diff-file=diff.txt`