### PR TITLE
 Add VER to the list of known LCov directives

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -324,6 +324,7 @@ class LcovCoverageReporter(BaseViolationReporter):
                 "BRF",
                 "BRH",
                 "BRDA",
+                "VER",
             ]:
                 # these are valid lines, but not we don't need them
                 continue

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -264,7 +264,7 @@ class XmlCoverageReporter(BaseViolationReporter):
 
 class LcovCoverageReporter(BaseViolationReporter):
     """
-    Query information from a Cobertura|Clover|JaCoCo XML coverage report.
+    Query information from a LCov coverage report.
     """
 
     def __init__(self, lcov_roots, src_roots=None):


### PR DESCRIPTION
Add VER directive to the list of known directives to support the LCov reports with it. VER is an optional directive that can be added by some tools. For example, gcovr is adding it right now.