### PR TITLE
GitHub warning annotations

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -96,7 +96,7 @@ def parse_coverage_args(argv):
 
     parser.add_argument(
         "--github-warning-annotations",
-        action="store_true",
+        action="store_false",
         default=None,
         help=GITHUB_WARNING_ANNOTATIONS_HELP,
     )

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -25,7 +25,7 @@ from diff_cover.violationsreporters.violations_reporter import (
 HTML_REPORT_HELP = "Diff coverage HTML output"
 JSON_REPORT_HELP = "Diff coverage JSON output"
 MARKDOWN_REPORT_HELP = "Diff coverage Markdown output"
-GITHUB_WARNING_ANNOTATIONS_HELP = "Diff coverage GitHub warning annotations output"
+GITHUB_WARNING_ANNOTATIONS_HELP = "Print diff coverage GitHub warning annotations to the console"
 COMPARE_BRANCH_HELP = "Branch to compare"
 CSS_FILE_HELP = "Write CSS into an external file"
 FAIL_UNDER_HELP = (
@@ -96,8 +96,8 @@ def parse_coverage_args(argv):
 
     parser.add_argument(
         "--github-warning-annotations",
-        metavar="FILENAME",
-        type=str,
+        action="store_true",
+        default=None,
         help=GITHUB_WARNING_ANNOTATIONS_HELP,
     )
 
@@ -216,7 +216,7 @@ def generate_coverage_report(
     css_file=None,
     json_report=None,
     markdown_report=None,
-    github_warning_annotations=None,
+    github_warning_annotations=False,
     ignore_staged=False,
     ignore_unstaged=False,
     include_untracked=False,
@@ -279,10 +279,9 @@ def generate_coverage_report(
         with open(markdown_report, "wb") as output_file:
             reporter.generate_report(output_file)
 
-    if github_warning_annotations is not None:
+    if github_warning_annotations:
         reporter = GitHubWarningAnnotationsReportGenerator(coverage, diff)
-        with open(github_warning_annotations, "wb") as output_file:
-            reporter.generate_report(output_file)
+        reporter.generate_report(sys.stdout.buffer)
 
     # Generate the report for stdout
     reporter = StringReportGenerator(coverage, diff, show_uncovered)

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -15,6 +15,7 @@ from diff_cover.report_generator import (
     JsonReportGenerator,
     MarkdownReportGenerator,
     StringReportGenerator,
+    GitHubWarningAnnotationsReportGenerator,
 )
 from diff_cover.violationsreporters.violations_reporter import (
     LcovCoverageReporter,
@@ -24,6 +25,7 @@ from diff_cover.violationsreporters.violations_reporter import (
 HTML_REPORT_HELP = "Diff coverage HTML output"
 JSON_REPORT_HELP = "Diff coverage JSON output"
 MARKDOWN_REPORT_HELP = "Diff coverage Markdown output"
+GITHUB_WARNING_ANNOTATIONS_HELP = "Diff coverage GitHub warning annotations output"
 COMPARE_BRANCH_HELP = "Branch to compare"
 CSS_FILE_HELP = "Write CSS into an external file"
 FAIL_UNDER_HELP = (
@@ -90,6 +92,13 @@ def parse_coverage_args(argv):
         metavar="FILENAME",
         type=str,
         help=MARKDOWN_REPORT_HELP,
+    )
+
+    parser.add_argument(
+        "--github-warning-annotations",
+        metavar="FILENAME",
+        type=str,
+        help=GITHUB_WARNING_ANNOTATIONS_HELP,
     )
 
     parser.add_argument(
@@ -207,6 +216,7 @@ def generate_coverage_report(
     css_file=None,
     json_report=None,
     markdown_report=None,
+    github_warning_annotations=None,
     ignore_staged=False,
     ignore_unstaged=False,
     include_untracked=False,
@@ -269,6 +279,11 @@ def generate_coverage_report(
         with open(markdown_report, "wb") as output_file:
             reporter.generate_report(output_file)
 
+    if github_warning_annotations is not None:
+        reporter = GitHubWarningAnnotationsReportGenerator(coverage, diff)
+        with open(github_warning_annotations, "wb") as output_file:
+            reporter.generate_report(output_file)
+
     # Generate the report for stdout
     reporter = StringReportGenerator(coverage, diff, show_uncovered)
     output_file = io.BytesIO() if quiet else sys.stdout.buffer
@@ -311,6 +326,7 @@ def main(argv=None, directory=None):
         html_report=arg_dict["html_report"],
         json_report=arg_dict["json_report"],
         markdown_report=arg_dict["markdown_report"],
+        github_warning_annotations=arg_dict["github_warning_annotations"],
         css_file=arg_dict["external_css_file"],
         ignore_staged=arg_dict["ignore_staged"],
         ignore_unstaged=arg_dict["ignore_unstaged"],

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -419,6 +419,14 @@ class StringReportGenerator(TemplateReportGenerator):
         super().__init__(violations_reporter, diff_reporter)
         self.include_snippets = show_uncovered
 
+class GitHubWarningAnnotationsReportGenerator(TemplateReportGenerator):
+    """
+    Generate a diff coverage report for GitHub warning annotations.
+    https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message
+    """
+
+    template_path = "github_coverage_warning_annotations.txt"
+
 
 class HtmlReportGenerator(TemplateReportGenerator):
     """

--- a/diff_cover/templates/github_coverage_warning_annotations.txt
+++ b/diff_cover/templates/github_coverage_warning_annotations.txt
@@ -1,0 +1,9 @@
+{% if src_stats %}
+{% for src_path, stats in src_stats|dictsort %}
+{% if stats.percent_covered < 100 %}
+{% for line in stats.violation_lines %}
+::warning file={{ src_path }},line={{ line }},title=Missing Coverage::Line {{ line }} missing coverage
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/diff_cover/templates/github_coverage_warning_annotations.txt
+++ b/diff_cover/templates/github_coverage_warning_annotations.txt
@@ -2,7 +2,8 @@
 {% for src_path, stats in src_stats|dictsort %}
 {% if stats.percent_covered < 100 %}
 {% for line in stats.violation_lines %}
-::warning file={{ src_path }},line={{ line }},title=Missing Coverage::Line {{ line }} missing coverage
+{% set splitLines = line.split("-") %}
+::warning file={{ src_path }},line={{ splitLines[0] }}{% if splitLines[1] %},endLine={{ splitLines[1] }}{% endif %},title=Missing Coverage::Line {{ line }} missing coverage
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -426,8 +426,23 @@ class TestGitHubWarningAnnotationsReportGenerator(BaseReportGeneratorTest):
         # Verify that we got the expected string
         expected = dedent(
             """
-        ::warning file=file1.py,line=10-11,title=Missing Coverage::Line 10-11 missing coverage
-        ::warning file=subdir/file2.py,line=10-11,title=Missing Coverage::Line 10-11 missing coverage
+        ::warning file=file1.py,line=10,endLine=11,title=Missing Coverage::Line 10-11 missing coverage
+        ::warning file=subdir/file2.py,line=10,endLine=11,title=Missing Coverage::Line 10-11 missing coverage
+        """
+        ).strip()
+
+        self.assert_report(expected)
+
+    def test_single_line(self):
+        self.set_src_paths_changed(["file.py"])
+        self.set_lines_changed("file.py", list(range(0, 100)))
+        self.set_violations("file.py", [Violation(10, None)])
+        self.set_measured("file.py", [2])
+
+        # Verify that we got the expected string
+        expected = dedent(
+            """
+        ::warning file=file.py,line=10,title=Missing Coverage::Line 10 missing coverage
         """
         ).strip()
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -15,6 +15,7 @@ from diff_cover.report_generator import (
     MarkdownReportGenerator,
     StringReportGenerator,
     TemplateReportGenerator,
+    GitHubWarningAnnotationsReportGenerator,
 )
 from diff_cover.violationsreporters.violations_reporter import (
     BaseViolationReporter,
@@ -412,6 +413,42 @@ class TestStringReportGenerator(BaseReportGeneratorTest):
         -------------
         """
         ).strip()
+
+        self.assert_report(expected)
+
+class TestGitHubWarningAnnotationsReportGenerator(BaseReportGeneratorTest):
+    REPORT_GENERATOR_CLASS = GitHubWarningAnnotationsReportGenerator
+
+    def test_generate_report(self):
+        # Generate a default report
+        self.use_default_values()
+
+        # Verify that we got the expected string
+        expected = dedent(
+            """
+        ::warning file=file1.py,line=10-11,title=Missing Coverage::Line 10-11 missing coverage
+        ::warning file=subdir/file2.py,line=10-11,title=Missing Coverage::Line 10-11 missing coverage
+        """
+        ).strip()
+
+        self.assert_report(expected)
+
+    def test_hundred_percent(self):
+        # Have the dependencies return an empty report
+        self.set_src_paths_changed(["file.py"])
+        self.set_lines_changed("file.py", list(range(0, 100)))
+        self.set_violations("file.py", [])
+        self.set_measured("file.py", [2])
+
+        expected = ""
+
+        self.assert_report(expected)
+
+    def test_empty_report(self):
+        # Have the dependencies return an empty report
+        # (this is the default)
+
+        expected = ""
 
         self.assert_report(expected)
 


### PR DESCRIPTION
I don't actually intend for this PR to be merged as-is, but more created it as a point of discussion (and for my own use, as it solves my immediate use-case).

Adds a report generator that prints GitHub style annotations to stdout.

Right now, only `warning` is supported - I couldn't immediately determine how to pass a command line switch to the generator without changing the base class.

Screenshot of `diff-cover coverage.lcov --github-warning-annotations` running in GitHub actions
|--|
|<img width="586" alt="Screenshot 2025-01-12 at 10 36 30" src="https://github.com/user-attachments/assets/332e3bcf-f7f0-4f7b-9b98-4cc94b790d13" />|
|<img width="586" alt="Screenshot 2025-01-12 at 11 15 53" src="https://github.com/user-attachments/assets/5e623e5b-d6f2-4af8-898d-787c0ba18b52" />|
