### PR TITLE
Fix escaped untracked files

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -5,6 +5,7 @@ Wrapper for `git diff` command.
 from textwrap import dedent
 
 from diff_cover.command_runner import CommandError, execute
+from diff_cover.util import to_unescaped_filename
 
 
 class GitDiffError(Exception):
@@ -109,7 +110,7 @@ class GitDiffTool:
         output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]
         if not output:
             return []
-        return [line for line in output.splitlines() if line]
+        return [to_unescaped_filename(line) for line in output.splitlines() if line]
 
 
 class GitDiffFileTool(GitDiffTool):

--- a/diff_cover/util.py
+++ b/diff_cover/util.py
@@ -1,3 +1,4 @@
+import ast
 import os.path
 import posixpath
 
@@ -15,3 +16,15 @@ def to_unix_path(path):
     :return: the unix version of that path
     """
     return posixpath.normpath(os.path.normcase(path).replace("\\", "/"))
+
+
+def to_unescaped_filename(filename: str) -> str:
+    """Try to unescape the given filename.
+
+    Some filenames given by git might be escaped. They can be identified by the
+    surrounding double quotes " (ASCII 34, See man git-status). Try to unescape
+    the filename.
+    """
+    if filename.startswith(chr(34)) and filename.endswith(chr(34)):
+        filename = ast.literal_eval(filename)
+    return filename

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,3 +11,13 @@ def test_to_unix_path():
     assert util.to_unix_path("foo\\bar") == "foo/bar"
     if sys.platform.startswith("win"):
         assert util.to_unix_path("FOO\\bar") == "foo/bar"
+
+
+def test_to_unescaped_filename():
+    """Test the to_unescaped_filename function."""
+    assert util.to_unescaped_filename('"\\\\\\\\"') == "\\\\"
+    assert util.to_unescaped_filename('"\\\\"') == "\\"
+    assert util.to_unescaped_filename('"\\"\\\\"') == '"\\'
+    assert util.to_unescaped_filename('"\\""') == '"'
+    assert util.to_unescaped_filename("some_file.py") == "some_file.py"
+    assert util.to_unescaped_filename("#$%") == "#$%"


### PR DESCRIPTION
Files that are escaped by git have to be unescaped so that the diff_reporter can open the file.