### PR TITLE
Resolve deprecation warnings of regex library

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,7 +59,7 @@ class ToolsIntegrationBase:
 
         Perhaps I will eat these words
         """
-        clean_content = re.sub("r'<style>.*</style>", content, "", re.DOTALL)
+        clean_content = re.sub("r'<style>.*</style>", content, "", flags=re.DOTALL)
         assert len(content) > len(clean_content)
         return clean_content
 


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings of regex library in Python3.13+ which you can see in the [CI logs](https://github.com/Bachmann1234/diff_cover/actions/runs/14787249997/job/41517764360#step:10:50):
```python
  /home/runner/work/diff_cover/diff_cover/tests/test_integration.py:62: DeprecationWarning: 'count' is passed as positional argument
    clean_content = re.sub("r'<style>.*</style>", content, "", re.DOTALL)
```