### PR TITLE
Removes getcwdu()

### DIFF
--- a/diff_cover/git_path.py
+++ b/diff_cover/git_path.py
@@ -24,10 +24,7 @@ class GitPathTool:
         Set the cwd that is used to manipulate paths.
         """
         if not cwd:
-            try:
-                cwd = os.getcwdu()
-            except AttributeError:
-                cwd = os.getcwd()
+            cwd = os.getcwd()
         if isinstance(cwd, bytes):
             cwd = cwd.decode(sys.getdefaultencoding())
         cls._cwd = cwd

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,10 +41,7 @@ class ToolsIntegrationBase:
 
         self._mock_popen = mocker.patch("subprocess.Popen")
         self._mock_sys = mocker.patch(f"{self.tool_module}.sys")
-        try:
-            self._mock_getcwd = mocker.patch(f"{self.tool_module}.os.getcwdu")
-        except AttributeError:
-            self._mock_getcwd = mocker.patch(f"{self.tool_module}.os.getcwd")
+        self._mock_getcwd = mocker.patch(f"{self.tool_module}.os.getcwd")
         self._git_root_path = cwd
         self._mock_getcwd.return_value = self._git_root_path
 


### PR DESCRIPTION
Removes python2 method that's been hiding there for a while..

[Note this only exists in py2](https://docs.python.org/2/library/os.html#os.getcwdu)