### PR TITLE
Adds lru_cache to untracked git call to get a ~2.56x speed improvement

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -2,6 +2,7 @@
 Wrapper for `git diff` command.
 """
 
+from functools import lru_cache
 from textwrap import dedent
 
 from diff_cover.command_runner import CommandError, execute
@@ -105,6 +106,7 @@ class GitDiffTool:
             0
         ]
 
+    @lru_cache(maxsize=1)
     def untracked(self):
         """Return the untracked files."""
         output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]


### PR DESCRIPTION
I've modified 20+ files, and running

`diff-quality --violations ruff.check --include-untracked`

Without `@lru_cache`: (with linux `time` infront)
```
diff-quality --violations ruff.check --include-untracked  0.32s user 0.40s system 67% cpu 1.068 total
diff-quality --violations ruff.check --include-untracked  0.32s user 0.42s system 67% cpu 1.097 total
diff-quality --violations ruff.check --include-untracked  0.32s user 0.43s system 67% cpu 1.117 total
diff-quality --violations ruff.check --include-untracked  0.33s user 0.41s system 67% cpu 1.099 total
```

WITH `@lru_cache`: (with linux `time` infront)
```
diff-quality --violations ruff.check --include-untracked  0.15s user 0.17s system 75% cpu 0.432 total
diff-quality --violations ruff.check --include-untracked  0.15s user 0.16s system 74% cpu 0.419 total
diff-quality --violations ruff.check --include-untracked  0.15s user 0.15s system 76% cpu 0.399 total
diff-quality --violations ruff.check --include-untracked  0.16s user 0.18s system 79% cpu 0.422 total
```

_hint_: less is better 😉 

----

<details>
  <summary>Here is how I found this:</summary>

(diff)
```
diff --git a/diff_cover/command_runner.py b/diff_cover/command_runner.py
index 0761dc1..9ae263d 100644
--- a/diff_cover/command_runner.py
+++ b/diff_cover/command_runner.py
@@ -25,6 +25,7 @@ def execute(command, exit_codes=None):
 
     stdout_pipe = subprocess.PIPE
     process = subprocess.Popen(command, stdout=stdout_pipe, stderr=stdout_pipe)
+    print("*"*10, command)
     try:
         stdout, stderr = process.communicate()
     except OSError:
@@ -53,6 +54,7 @@ def run_command_for_code(command):
     """
     Returns command's exit code.
     """
+    print("*"*10, command)
     try:
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
```

here is the output of the current code:
```
********** ['git', 'rev-parse', '--show-toplevel', '--encoding=utf-8']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0', 'origin/main...HEAD']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0', '--cached']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['flake8', '--version']
********** ['flake8', b'diff_cover/command_runner.py']
********** ['flake8', b'diff_cover/git_diff.py']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['git', 'ls-files', '--exclude-standard', '--others']
```

With my change:
```
********** ['git', 'rev-parse', '--show-toplevel', '--encoding=utf-8']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0', 'origin/main...HEAD']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0', '--cached']
********** ['git', '-c', 'diff.mnemonicprefix=no', '-c', 'diff.noprefix=no', 'diff', '--no-color', '--no-ext-diff', '-U0']
********** ['git', 'ls-files', '--exclude-standard', '--others']
********** ['flake8', '--version']
********** ['flake8', b'diff_cover/command_runner.py']
********** ['flake8', b'diff_cover/git_diff.py']
```
</details>