### PR TITLE
Removes lru_cache

### DIFF
--- a/diff_cover/git_diff.py
+++ b/diff_cover/git_diff.py
@@ -2,7 +2,6 @@
 Wrapper for `git diff` command.
 """
 
-from functools import lru_cache
 from textwrap import dedent
 
 from diff_cover.command_runner import CommandError, execute
@@ -42,6 +41,7 @@ class GitDiffTool:
          :param bool ignore_whitespace:
             Perform a diff but ignore any and all whitespace.
         """
+        self._untracked_cache = None
         self.range_notation = range_notation
         self._default_git_args = [
             "git",
@@ -106,9 +106,11 @@ class GitDiffTool:
             0
         ]
 
-    @lru_cache(maxsize=1)
     def untracked(self):
         """Return the untracked files."""
+        if self._untracked_cache is not None:
+            return self._untracked_cache
+
         output = execute(["git", "ls-files", "--exclude-standard", "--others"])[0]
         if not output:
             return []


### PR DESCRIPTION
Related:
* https://github.com/Bachmann1234/diff_cover/pull/467

Whoopsie! Not that it _really_ matters, since this tool is only ran as a one-off. But according to [this](https://docs.astral.sh/ruff/rules/cached-instance-method/) it can lead to memory leaks. Honestly I'm changing this for 2 reasons:
1. i want ruff warning to shut up about it -- i hate warnings
2. i'm concerned with this issue when running tests (as a very distant issue at the very-very back part of my mind 😉 )

Gotta love ruff!

---

Currently:
```
diff-quality --violations flake8 --include-untracked  0.24s user 0.13s system 72% cpu 0.500 total
diff-quality --violations flake8 --include-untracked  0.23s user 0.12s system 72% cpu 0.487 total
diff-quality --violations flake8 --include-untracked  0.24s user 0.12s system 71% cpu 0.496 total
diff-quality --violations flake8 --include-untracked  0.23s user 0.11s system 69% cpu 0.491 total
```
This change:
```
Your branch is up to date with 'origin/dev/remove-lru-cache'.
diff-quality --violations flake8 --include-untracked  0.24s user 0.12s system 69% cpu 0.501 total
diff-quality --violations flake8 --include-untracked  0.24s user 0.12s system 69% cpu 0.517 total
diff-quality --violations flake8 --include-untracked  0.24s user 0.12s system 71% cpu 0.500 total
diff-quality --violations flake8 --include-untracked  0.23s user 0.12s system 72% cpu 0.485 total
```

There is little not no difference