### PR TITLE
Update coverage ignore lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,14 @@ omit = ["./tests/*"]
 
 [tool.coverage.report]
 show_missing = true
+exclude_also = [
+    "if typing.TYPE_CHECKING:",
+    "if TYPE_CHECKING:",
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise NotImplementedError",
+    "raise AssertionError",
+    "pass",
+]
 
 [tool.coverage.html]
 show_contexts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ show_missing = true
 exclude_also = [
     "if typing.TYPE_CHECKING:",
     "if TYPE_CHECKING:",
-    # Don't complain if tests don't hit defensive assertion code:
     "raise NotImplementedError",
     "raise AssertionError",
     "pass",


### PR DESCRIPTION
There is no point to running coverage on these lines, main example:
* 	`raise NotImplementedError`	