### PR TITLE
Adds test to handle condition with multiple xml and lcov

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -81,7 +81,7 @@ def parse_coverage_args(argv):
     """
     parser = argparse.ArgumentParser(description=DESCRIPTION)
 
-    parser.add_argument("coverage_file", type=str, help=COVERAGE_FILE_HELP, nargs="+")
+    parser.add_argument("coverage_files", type=str, help=COVERAGE_FILE_HELP, nargs="+")
 
     parser.add_argument(
         "--format",
@@ -236,6 +236,8 @@ def generate_coverage_report(
         for coverage_file in coverage_files
         if not coverage_file.endswith(".xml")
     ]
+    if xml_roots and lcov_roots:
+        raise ValueError("Mixing LCov and XML reports is not supported yet")
     if xml_roots:
         coverage = XmlCoverageReporter(xml_roots, src_roots, expand_coverage_report)
     else:
@@ -349,7 +351,7 @@ def main(argv=None, directory=None):
         diff_tool = GitDiffFileTool(arg_dict["diff_file"])
 
     percent_covered = generate_coverage_report(
-        arg_dict["coverage_file"],
+        arg_dict["coverage_files"],
         arg_dict["compare_branch"],
         diff_tool,
         report_formats=arg_dict["format"],

--- a/tests/test_diff_cover_main.py
+++ b/tests/test_diff_cover_main.py
@@ -12,7 +12,7 @@ def test_parse_coverage_file():
 
     arg_dict = parse_coverage_args(argv)
 
-    assert arg_dict["coverage_file"] == ["build/tests/coverage.xml"]
+    assert arg_dict["coverage_files"] == ["build/tests/coverage.xml"]
     assert arg_dict["compare_branch"] == "origin/other"
     assert arg_dict["diff_range_notation"] == "..."
 
@@ -22,7 +22,7 @@ def test_parse_range_notation(capsys):
 
     arg_dict = parse_coverage_args(argv)
 
-    assert arg_dict["coverage_file"] == ["build/tests/coverage.xml"]
+    assert arg_dict["coverage_files"] == ["build/tests/coverage.xml"]
     assert arg_dict["diff_range_notation"] == ".."
 
     with pytest.raises(SystemExit) as e:

--- a/tests/test_diff_cover_tool.py
+++ b/tests/test_diff_cover_tool.py
@@ -11,9 +11,9 @@ def test_parse_with_html_report():
     argv = ["reports/coverage.xml", "--format", "html:diff_cover.html"]
     arg_dict = parse_coverage_args(argv)
 
-    assert arg_dict.get("coverage_file") == ["reports/coverage.xml"]
-    assert arg_dict.get("format") == {"html": "diff_cover.html"}
-    assert not arg_dict.get("ignore_unstaged")
+    assert arg_dict["coverage_files"] == ["reports/coverage.xml"]
+    assert arg_dict["format"] == {"html": "diff_cover.html"}
+    assert not arg_dict["ignore_unstaged"]
 
 
 def test_report_path_with_colon():
@@ -32,9 +32,9 @@ def test_parse_with_no_report():
     argv = ["reports/coverage.xml"]
     arg_dict = parse_coverage_args(argv)
 
-    assert arg_dict.get("coverage_file") == ["reports/coverage.xml"]
-    assert arg_dict.get("format") == {}
-    assert not arg_dict.get("ignore_unstaged")
+    assert arg_dict["coverage_files"] == ["reports/coverage.xml"]
+    assert arg_dict["format"] == {}
+    assert not arg_dict["ignore_unstaged"]
 
 
 def test_parse_with_multiple_reports():
@@ -45,9 +45,9 @@ def test_parse_with_multiple_reports():
     ]
     arg_dict = parse_coverage_args(argv)
 
-    assert arg_dict.get("coverage_file") == ["reports/coverage.xml"]
-    assert arg_dict.get("format") == {"html": "report.html", "markdown": "report.md"}
-    assert not arg_dict.get("ignore_unstaged")
+    assert arg_dict["coverage_files"] == ["reports/coverage.xml"]
+    assert arg_dict["format"] == {"html": "report.html", "markdown": "report.md"}
+    assert not arg_dict["ignore_unstaged"]
 
 
 def test_parse_with_multiple_old_reports(recwarn):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -375,6 +375,13 @@ class TestDiffCoverIntegration:
         assert runbin(["--show-uncovered", "coverage.xml"]) == 0
         compare_console("show_uncovered_lines_console.txt", capsys.readouterr().out)
 
+    def test_multiple_lcov_xml_reports(self, runbin, patch_git_command, capsys):
+        patch_git_command.set_stdout("git_diff_add.txt")
+        with pytest.raises(
+            ValueError, match="Mixing LCov and XML reports is not supported yet"
+        ):
+            runbin(["--show-uncovered", "coverage.xml", "lcov.info"])
+
     def test_expand_coverage_report_complete_report(
         self, runbin, patch_git_command, capsys
     ):


### PR DESCRIPTION
* Renames `coverage_file` -> `coverage_files` so no one gets confused by this again
  * Update tests to new name
* Updates the code format to better align with modern python practices... `black` was yelling at me
* Adds test for multiple `coverage_files` when you mix lcov and xml