### PR TITLE
Update coverage ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,10 @@ show_missing = true
 exclude_also = [
     "if typing.TYPE_CHECKING:",
     "if TYPE_CHECKING:",
+    "if __name__ == \"__main__\":",
     "raise NotImplementedError",
     "raise AssertionError",
-    "pass",
+    "^\\s*pass\\s*$",
 ]
 
 [tool.coverage.html]


### PR DESCRIPTION
* `pass` was too generic and was matching code like:
  * `if percent_passing >= fail_under:` and...
  * `percent_passing = generate_quality_report(` ...
* The `__main__` is something we wont be be able to test directly as that is ran at run time, by the time the test tries to test it, it's too late.