### PR TITLE
Update test code

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -157,7 +157,7 @@ def _hunk_entry(start, end, modified_lines):
     # for before/after the change, but since we're only interested
     # in after the change, we use the same numbers for both.
     length = end - start
-    output.append("@@ -{0},{1} +{0},{1} @@".format(start, length))
+    output.append(f"@@ -{start},{length} +{start},{length} @@")
 
     # Output line modifications
     for line_number in range(start, end + 1):

--- a/tests/test_diff_quality_main.py
+++ b/tests/test_diff_quality_main.py
@@ -69,7 +69,6 @@ def test_parse_invalid_arg():
 
     for argv in invalid_argv:
         with pytest.raises(SystemExit):
-            print(f"args = {argv}")
             parse_quality_args(argv)
 
 

--- a/tests/test_diff_reporter.py
+++ b/tests/test_diff_reporter.py
@@ -478,11 +478,9 @@ def test_git_diff_error(
 
         # Expect that both methods that access git diff raise an error
         with pytest.raises(GitDiffError):
-            print("src_paths_changed() " "should fail for {}".format(diff_str))
             diff.src_paths_changed()
 
         with pytest.raises(GitDiffError):
-            print(f"lines_changed() should fail for {diff_str}")
             diff.lines_changed("subdir/file1.py")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,7 +145,7 @@ class TestDiffCoverIntegration:
 
     @pytest.fixture
     def runbin(self, cwd):
-        del cwd
+        del cwd  # fixtures cannot use pytest.mark.usefixtures
         return lambda x: diff_cover_tool.main(["diff-cover", *x])
 
     def test_added_file_html(self, runbin, patch_git_command):
@@ -398,7 +398,7 @@ class TestDiffQualityIntegration:
 
     @pytest.fixture
     def runbin(self, cwd):
-        del cwd
+        del cwd  # fixtures cannot use pytest.mark.usefixtures
         return lambda x: diff_quality_tool.main(["diff-quality", *x])
 
     def test_git_diff_error_diff_quality(self, runbin, patch_git_command):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,6 +145,7 @@ class TestDiffCoverIntegration:
 
     @pytest.fixture
     def runbin(self, cwd):
+        del cwd
         return lambda x: diff_cover_tool.main(["diff-cover", *x])
 
     def test_added_file_html(self, runbin, patch_git_command):
@@ -256,7 +257,7 @@ class TestDiffCoverIntegration:
         assert runbin(["coverage.xml"]) == 0
         compare_console("changed_console_report.txt", capsys.readouterr().out)
 
-    def test_moved_file_html(self, runbin, patch_git_command, capsys):
+    def test_moved_file_html(self, runbin, patch_git_command):
         patch_git_command.set_stdout("git_diff_moved.txt")
         assert (
             runbin(["moved_coverage.xml", "--format", "html:dummy/diff_coverage.html"])
@@ -397,6 +398,7 @@ class TestDiffQualityIntegration:
 
     @pytest.fixture
     def runbin(self, cwd):
+        del cwd
         return lambda x: diff_quality_tool.main(["diff-quality", *x])
 
     def test_git_diff_error_diff_quality(self, runbin, patch_git_command):

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -304,7 +304,7 @@ class TestJsonReportGenerator(BaseReportGeneratorTest):
     def test_hundred_percent(self):
         # Have the dependencies return an empty report
         self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(0, 100)))
+        self.set_lines_changed("file.py", list(range(100)))
         self.set_violations("file.py", [])
         self.set_measured("file.py", [2])
 
@@ -377,7 +377,7 @@ class TestStringReportGenerator(BaseReportGeneratorTest):
     def test_hundred_percent(self):
         # Have the dependencies return an empty report
         self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(0, 100)))
+        self.set_lines_changed("file.py", list(range(100)))
         self.set_violations("file.py", [])
         self.set_measured("file.py", [2])
 
@@ -484,7 +484,7 @@ class TestMarkdownReportGenerator(BaseReportGeneratorTest):
     def test_hundred_percent(self):
         # Have the dependencies return an empty report
         self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(0, 100)))
+        self.set_lines_changed("file.py", list(range(100)))
         self.set_violations("file.py", [])
         self.set_measured("file.py", [2])
 

--- a/tests/test_violations_reporter.py
+++ b/tests/test_violations_reporter.py
@@ -1598,7 +1598,7 @@ class TestPylintQualityReporterTest:
         ]
 
     def test_unicode_continuation_char(self, process_patcher):
-        process_patcher((b"file.py:2: [W1401]" b" Invalid char '\xc3'", ""), 0)
+        process_patcher((b"file.py:2: [W1401] Invalid char '\xc3'", ""), 0)
         # Since we are replacing characters we can't interpet, this should
         # return a valid string with the char replaced with '?'
         quality = QualityReporter(PylintDriver())


### PR DESCRIPTION
* Removes old `print` statements in tests
* Updates bad split string
* Updates `.format()` string to use `f-string`
* The `0` in `range` is not needed -- `ruff` said to take it out
* Removed signature argument that was not being used