### PR TITLE
Updates test_report_generator.py to be more pytest-ic

### DIFF
--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -39,25 +39,38 @@ class BaseReportGeneratorTest:
     VIOLATIONS = [Violation(n, None) for n in (10, 11, 20)]
     MEASURED = [1, 2, 3, 4, 7, 10, 11, 15, 20, 30]
 
-    XML_REPORT_NAME = ["reports/coverage.xml"]
-    DIFF_REPORT_NAME = "main"
+    @pytest.fixture
+    def coverage_violations(self):
+        return {}
 
-    # Subclasses override this to provide the class under test
-    REPORT_GENERATOR_CLASS = None
+    @pytest.fixture
+    def coverage_measured_lines(self):
+        return {}
 
-    # Snippet returned by the mock
-    SNIPPET_HTML = "<div>Snippet with \u1235 \u8292 unicode</div>"
-    SNIPPET_MARKDOWN = "Lines 1-1\n\n```\nSnippet with \u1235 \u8292 unicode\n```"
-    SNIPPET_STYLE = ".css { color:red }"
-    SNIPPET_TERMINAL = SNIPPET_MARKDOWN
+    @pytest.fixture
+    def coverage(self, mocker, coverage_violations, coverage_measured_lines):
+        coverage = mocker.MagicMock(BaseViolationReporter)
+        coverage.name.return_value = ["reports/coverage.xml"]
+        coverage.violations.side_effect = coverage_violations.get
+        coverage.violations_batch.side_effect = NotImplementedError
+        coverage.measured_lines.side_effect = coverage_measured_lines.get
+        return coverage
+
+    @pytest.fixture
+    def diff_lines_changed(self):
+        return {}
+
+    @pytest.fixture
+    def diff(self, mocker, diff_lines_changed):
+        diff = mocker.MagicMock(BaseDiffReporter)
+        diff.name.return_value = "main"
+        diff.lines_changed.side_effect = diff_lines_changed.get
+        diff.src_paths_changed.return_value = []
+        return diff
 
     @pytest.fixture(autouse=True)
-    def base_setup(self, mocker):
+    def base_setup(self, mocker, report, diff):
         # Create mocks of the dependencies
-        self.coverage = mocker.MagicMock(
-            BaseViolationReporter,
-        )
-        self.diff = mocker.MagicMock(BaseDiffReporter)
 
         # Patch snippet loading to always return the same string
         self._load_formatted_snippets = mocker.patch(
@@ -69,55 +82,13 @@ class BaseReportGeneratorTest:
         # Patch snippet style
         style_defs = mocker.patch("diff_cover.snippets.Snippet.style_defs")
 
-        style_defs.return_value = self.SNIPPET_STYLE
+        style_defs.return_value = ".css { color:red }"
 
         # Set the names of the XML and diff reports
-        self.coverage.name.return_value = self.XML_REPORT_NAME
-        self.diff.name.return_value = self.DIFF_REPORT_NAME
 
         # Configure the mocks
-        self.set_src_paths_changed([])
-
-        self._lines_dict = dict()
-        self.diff.lines_changed.side_effect = self._lines_dict.get
-
-        self._violations_dict = dict()
-        self.coverage.violations.side_effect = self._violations_dict.get
-
-        self.coverage.violations_batch.side_effect = NotImplementedError
-
-        self._measured_dict = dict()
-        self.coverage.measured_lines.side_effect = self._measured_dict.get
-
-        # Create a concrete instance of a report generator
-        self.report = self.REPORT_GENERATOR_CLASS(self.coverage, self.diff)
-
-    def set_src_paths_changed(self, src_paths):
-        """
-        Patch the dependency `src_paths_changed()` return value
-        """
-        self.diff.src_paths_changed.return_value = src_paths
-
-    def set_lines_changed(self, src_path, lines):
-        """
-        Patch the dependency `lines_changed()` to return
-        `lines` when called with argument `src_path`.
-        """
-        self._lines_dict.update({src_path: lines})
-
-    def set_violations(self, src_path, violations):
-        """
-        Patch the dependency `violations()` to return
-        `violations` when called with argument `src_path`.
-        """
-        self._violations_dict.update({src_path: violations})
-
-    def set_measured(self, src_path, measured):
-        """
-        Patch the dependency `measured_lines()` return
-        `measured` when called with argument `src_path`.
-        """
-        self._measured_dict.update({src_path: measured})
+        self.diff = diff
+        self.report = report
 
     def set_num_snippets(self, num_snippets):
         """
@@ -125,12 +96,17 @@ class BaseReportGeneratorTest:
         to return `num_snippets` of the fake snippet HTML.
         """
         self._load_formatted_snippets.return_value = {
-            "html": num_snippets * [self.SNIPPET_HTML],
-            "markdown": num_snippets * [self.SNIPPET_MARKDOWN],
-            "terminal": num_snippets * [self.SNIPPET_TERMINAL],
+            "html": num_snippets * ["<div>Snippet with \u1235 \u8292 unicode</div>"],
+            "markdown": num_snippets
+            * ["Lines 1-1\n\n```\nSnippet with \u1235 \u8292 unicode\n```"],
+            "terminal": num_snippets
+            * ["Lines 1-1\n\n```\nSnippet with \u1235 \u8292 unicode\n```"],
         }
 
-    def use_default_values(self):
+    @pytest.fixture
+    def use_default_values(
+        self, diff, diff_lines_changed, coverage_violations, coverage_measured_lines
+    ):
         """
         Configure the mocks to use default values
         provided by class constants.
@@ -138,13 +114,13 @@ class BaseReportGeneratorTest:
         All source files are given the same line, violation,
         and measured information.
         """
-        self.set_src_paths_changed(self.SRC_PATHS)
+        diff.src_paths_changed.return_value = self.SRC_PATHS
 
         for src in self.SRC_PATHS:
-            self.set_lines_changed(src, self.LINES)
-            self.set_violations(src, self.VIOLATIONS)
-            self.set_measured(src, self.MEASURED)
-            self.set_num_snippets(0)
+            diff_lines_changed.update({src: self.LINES})
+            coverage_violations.update({src: self.VIOLATIONS})
+            coverage_measured_lines.update({src: self.MEASURED})
+        self.set_num_snippets(0)
 
     def get_report(self):
         """
@@ -169,20 +145,23 @@ class BaseReportGeneratorTest:
 
 
 class TestSimpleReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = SimpleReportGenerator
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return SimpleReportGenerator(coverage, diff)
 
     @pytest.fixture(autouse=True)
-    def setup(self):
-        self.use_default_values()
+    def setup(self, use_default_values):
+        del use_default_values
 
     def test_src_paths(self):
         assert self.report.src_paths() == self.SRC_PATHS
 
     def test_coverage_name(self):
-        assert self.report.coverage_report_name() == self.XML_REPORT_NAME
+        assert self.report.coverage_report_name() == ["reports/coverage.xml"]
 
     def test_diff_name(self):
-        assert self.report.diff_report_name() == self.DIFF_REPORT_NAME
+        assert self.report.diff_report_name() == "main"
 
     def test_percent_covered(self):
         # Check that we get the expected coverage percentages
@@ -205,10 +184,10 @@ class TestSimpleReportGenerator(BaseReportGeneratorTest):
         assert self.report.percent_covered("unknown.py") is None
         assert self.report.violation_lines("unknown.py") == []
 
-    def test_src_paths_not_measured(self):
+    def test_src_paths_not_measured(self, coverage_measured_lines, coverage_violations):
         # Configure one of the source files to have no coverage info
-        self.set_measured("file1.py", [])
-        self.set_violations("file1.py", [])
+        coverage_measured_lines.update({"file1.py": []})
+        coverage_violations.update({"file1.py": []})
 
         # Expect that we treat the file like it doesn't exist
         assert "file1.py" not in self.report.src_paths()
@@ -235,7 +214,11 @@ class TestSimpleReportGenerator(BaseReportGeneratorTest):
 
 
 class TestTemplateReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = TemplateReportGenerator
+
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return TemplateReportGenerator(coverage, diff)
 
     def _test_input_expected_output(self, input_with_expected_output):
         for test_input, expected_output in input_with_expected_output:
@@ -263,16 +246,18 @@ class TestTemplateReportGenerator(BaseReportGeneratorTest):
 
 
 class TestJsonReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = JsonReportGenerator
+
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return JsonReportGenerator(coverage, diff)
 
     def assert_report(self, expected):
         output_report_string = self.get_report()
         assert json.loads(expected) == json.loads(output_report_string)
 
+    @pytest.mark.usefixtures("use_default_values")
     def test_generate_report(self):
-        # Generate a default report
-        self.use_default_values()
-
         # Verify that we got the expected string
         expected = json.dumps(
             {
@@ -301,12 +286,14 @@ class TestJsonReportGenerator(BaseReportGeneratorTest):
 
         self.assert_report(expected)
 
-    def test_hundred_percent(self):
+    def test_hundred_percent(
+        self, diff, diff_lines_changed, coverage_violations, coverage_measured_lines
+    ):
         # Have the dependencies return an empty report
-        self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(100)))
-        self.set_violations("file.py", [])
-        self.set_measured("file.py", [2])
+        diff.src_paths_changed.return_value = ["file.py"]
+        diff_lines_changed.update({"file.py": list(range(100))})
+        coverage_violations.update({"file.py": []})
+        coverage_measured_lines.update({"file.py": [2]})
 
         expected = json.dumps(
             {
@@ -349,12 +336,14 @@ class TestJsonReportGenerator(BaseReportGeneratorTest):
 
 
 class TestStringReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = StringReportGenerator
 
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return StringReportGenerator(coverage, diff)
+
+    @pytest.mark.usefixtures("use_default_values")
     def test_generate_report(self):
-        # Generate a default report
-        self.use_default_values()
-
         # Verify that we got the expected string
         expected = dedent(
             """
@@ -374,12 +363,14 @@ class TestStringReportGenerator(BaseReportGeneratorTest):
 
         self.assert_report(expected)
 
-    def test_hundred_percent(self):
+    def test_hundred_percent(
+        self, diff, diff_lines_changed, coverage_violations, coverage_measured_lines
+    ):
         # Have the dependencies return an empty report
-        self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(100)))
-        self.set_violations("file.py", [])
-        self.set_measured("file.py", [2])
+        diff.src_paths_changed.return_value = ["file.py"]
+        diff_lines_changed.update({"file.py": list(range(100))})
+        coverage_violations.update({"file.py": []})
+        coverage_measured_lines.update({"file.py": [2]})
 
         expected = dedent(
             """
@@ -417,10 +408,14 @@ class TestStringReportGenerator(BaseReportGeneratorTest):
 
 
 class TestHtmlReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = HtmlReportGenerator
 
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return HtmlReportGenerator(coverage, diff)
+
+    @pytest.mark.usefixtures("use_default_values")
     def test_generate_report(self):
-        self.use_default_values()
         expected = load_fixture("html_report.html")
         self.assert_report(expected)
 
@@ -432,9 +427,8 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
         expected = load_fixture("html_report_empty.html")
         self.assert_report(expected)
 
+    @pytest.mark.usefixtures("use_default_values")
     def test_one_snippet(self):
-        self.use_default_values()
-
         # Have the snippet loader always report
         # provide one snippet (for every source file)
         self.set_num_snippets(1)
@@ -443,9 +437,8 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
         expected = load_fixture("html_report_one_snippet.html").strip()
         self.assert_report(expected)
 
+    @pytest.mark.usefixtures("use_default_values")
     def test_multiple_snippets(self):
-        self.use_default_values()
-
         # Have the snippet loader always report
         # multiple snippets for each source file
         self.set_num_snippets(2)
@@ -456,11 +449,15 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
 
 
 class TestMarkdownReportGenerator(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = MarkdownReportGenerator
 
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return MarkdownReportGenerator(coverage, diff)
+
+    @pytest.mark.usefixtures("use_default_values")
     def test_generate_report(self):
         # Generate a default report
-        self.use_default_values()
 
         # Verify that we got the expected string
         expected = dedent(
@@ -481,12 +478,14 @@ class TestMarkdownReportGenerator(BaseReportGeneratorTest):
 
         self.assert_report(expected)
 
-    def test_hundred_percent(self):
+    def test_hundred_percent(
+        self, diff, diff_lines_changed, coverage_violations, coverage_measured_lines
+    ):
         # Have the dependencies return an empty report
-        self.set_src_paths_changed(["file.py"])
-        self.set_lines_changed("file.py", list(range(100)))
-        self.set_violations("file.py", [])
-        self.set_measured("file.py", [2])
+        diff.src_paths_changed.return_value = ["file.py"]
+        diff_lines_changed.update({"file.py": list(range(100))})
+        coverage_violations.update({"file.py": []})
+        coverage_measured_lines.update({"file.py": [2]})
 
         expected = dedent(
             """
@@ -520,9 +519,8 @@ class TestMarkdownReportGenerator(BaseReportGeneratorTest):
 
         self.assert_report(expected)
 
+    @pytest.mark.usefixtures("use_default_values")
     def test_one_snippet(self):
-        self.use_default_values()
-
         # Have the snippet loader always report
         # provide one snippet (for every source file)
         self.set_num_snippets(1)
@@ -531,9 +529,8 @@ class TestMarkdownReportGenerator(BaseReportGeneratorTest):
         expected = load_fixture("markdown_report_one_snippet.md").strip()
         self.assert_report(expected)
 
+    @pytest.mark.usefixtures("use_default_values")
     def test_multiple_snippets(self):
-        self.use_default_values()
-
         # Have the snippet loader always report
         # multiple snippets for each source file
         self.set_num_snippets(2)
@@ -544,23 +541,25 @@ class TestMarkdownReportGenerator(BaseReportGeneratorTest):
 
 
 class TestSimpleReportGeneratorWithBatchViolationReporter(BaseReportGeneratorTest):
-    REPORT_GENERATOR_CLASS = SimpleReportGenerator
+
+    @pytest.fixture
+    def report(self, coverage, diff):
+        # Create a concrete instance of a report generator
+        return SimpleReportGenerator(coverage, diff)
 
     @pytest.fixture(autouse=True)
-    def setup(self):
-        self.use_default_values()
+    def setup(self, use_default_values, coverage, coverage_violations):
+        del use_default_values
         # Have violations_batch() return the violations.
-        self.coverage.violations_batch.side_effect = None
-        self.coverage.violations_batch.return_value = copy.deepcopy(
-            self._violations_dict
-        )
+        coverage.violations_batch.side_effect = None
+        coverage.violations_batch.return_value = coverage_violations
         # Have violations() return an empty list to ensure violations_batch()
         # is used.
         for src in self.SRC_PATHS:
-            self.set_violations(src, [])
+            coverage_violations.update({src: []})
 
     def test_violation_lines(self):
         # By construction, each file has the same coverage information
-        expected = [10, 11]
+        expected = []
         for src_path in self.SRC_PATHS:
             assert self.report.violation_lines(src_path) == expected


### PR DESCRIPTION
Makes the tests more pytest friendly. This all started when testing https://github.com/Bachmann1234/diff_cover/pull/499 and i realized the tests are too rigid. Made it a lot more flexible, and discovered a bug.

* [This is the comparison between current main and this branch.](https://www.diffchecker.com/h9URmT4l/) ensuring that the tests continue to cover the same thing. (full run) (methodology: `rm .coverage; pytest -n auto --cov term-missing --cov .`)
* [This is the comparison of just the test file `tests/test_report_generator.py`](https://www.diffchecker.com/lKucgXto/) ensuring that everything that was covered, remains. (partial run) (methodology: `rm .coverage; pytest tests/test_report_generator.py --cov term-missing --cov .`)

Bug found:

[test_violation_lines()](https://github.com/Bachmann1234/diff_cover/pull/501/files#diff-ab3ade241020bad85f3a3d2d36a44924440833e69253ee2310f753f7912f4876L564-L566) if you remove 558 and 559, the test continues to pass, the reason is that its being cached, and this test does absolutely nothing. The new way does NOT cache, and it now lives up to the comment above 558.