### PR TITLE
Fixes bug when using diff-cover --format markdown:-

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -17,7 +17,7 @@ from diff_cover.report_generator import (
     MarkdownReportGenerator,
     StringReportGenerator,
 )
-from diff_cover.util import open_file
+from diff_cover.util import file_open, open_file
 from diff_cover.violationsreporters.violations_reporter import (
     LcovCoverageReporter,
     XmlCoverageReporter,
@@ -266,7 +266,7 @@ def generate_coverage_report(
     if "markdown" in report_formats:
         markdown_report = report_formats["markdown"] or MARKDOWN_REPORT_DEFAULT_PATH
         reporter = MarkdownReportGenerator(coverage, diff)
-        with open(markdown_report, "wb") as output_file:
+        with file_open(markdown_report, "wb") as output_file:
             reporter.generate_report(output_file)
 
     # Generate the report for stdout

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -17,7 +17,7 @@ from diff_cover.report_generator import (
     MarkdownReportGenerator,
     StringReportGenerator,
 )
-from diff_cover.util import file_open, open_file
+from diff_cover.util import open_file
 from diff_cover.violationsreporters.violations_reporter import (
     LcovCoverageReporter,
     XmlCoverageReporter,
@@ -266,7 +266,7 @@ def generate_coverage_report(
     if "markdown" in report_formats:
         markdown_report = report_formats["markdown"] or MARKDOWN_REPORT_DEFAULT_PATH
         reporter = MarkdownReportGenerator(coverage, diff)
-        with file_open(markdown_report, "wb") as output_file:
+        with open_file(markdown_report, "wb") as output_file:
             reporter.generate_report(output_file)
 
     # Generate the report for stdout

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -98,8 +98,7 @@ def patch_git_command(patch_popen, mocker):
 
 def clean_html(html, clear_inline_css):
     if clear_inline_css:
-        clean_content = re.compile("<style>.*</style>", flags=re.DOTALL)
-        html = clean_content.sub("", html)
+        html = re.sub("<style>.*</style>", "", html, flags=re.DOTALL)
     return html.strip()
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -96,21 +96,24 @@ def patch_git_command(patch_popen, mocker):
     return helper
 
 
+def clean_html(html, clear_inline_css):
+    if clear_inline_css:
+        clean_content = re.compile("<style>.*</style>", flags=re.DOTALL)
+        html = clean_content.sub("", html)
+    return html.strip()
+
+
 def compare_html(expected_html_path, html_report_path, clear_inline_css=True):
-    clean_content = re.compile("<style>.*</style>", flags=re.DOTALL)
     expected_file = open(expected_html_path, encoding="utf-8")
     html_report = open(html_report_path, encoding="utf-8")
 
     with expected_file, html_report:
-        html = html_report.read()
-        expected = expected_file.read()
-        if clear_inline_css:
-            # The CSS is provided by pygments and changes fairly often.
-            # Im ok with simply saying "There was css"
-            # Perhaps I will eat these words
-            html = clean_content.sub("", html)
-            expected = clean_content.sub("", expected)
-        assert expected.strip() == html.strip()
+        # The CSS is provided by pygments and changes fairly often.
+        # Im ok with simply saying "There was css"
+        # Perhaps I will eat these words
+        html = clean_html(html_report.read(), clear_inline_css)
+        expected = clean_html(expected_file.read(), clear_inline_css)
+        assert expected == html
 
 
 def compare_markdown(expected_file_path, actual_file_path):
@@ -178,6 +181,36 @@ class TestDiffCoverIntegration:
         compare_html("add_html_report.html", "dummy/diff_coverage.html")
         compare_json("add_json_report.json", "dummy/diff_coverage.json")
         compare_markdown("add_markdown_report.md", "dummy/diff_coverage.md")
+
+    def test_all_reports_with_stdout(self, runbin, patch_git_command, capsys):
+        patch_git_command.set_stdout("git_diff_add.txt")
+        assert (
+            runbin(
+                [
+                    "coverage.xml",
+                    "--format",
+                    "html:-,json:-,markdown:-",
+                ]
+            )
+            == 0
+        )
+        output = capsys.readouterr().out
+        with open("add_console_report.txt", "r", encoding="utf-8") as f:
+            actual = f.read()
+            assert actual in output
+        with open("add_html_report.html", "r", encoding="utf-8") as f:
+            actual = clean_html(f.read(), clear_inline_css=True)
+            # can't compare the output inside <head> since it changes
+            # a lot so we just compare the body
+            actual = actual[actual.find("</head>") :]
+            assert len(actual) > 20
+            assert actual in output
+        with open("add_json_report.json", "r", encoding="utf-8") as f:
+            actual = json.dumps(json.loads(f.read()))
+            assert actual in output
+        with open("add_markdown_report.md", "r", encoding="utf-8") as f:
+            actual = f.read()
+            assert actual in output
 
     def test_added_file_console_lcov(self, runbin, patch_git_command, capsys):
         patch_git_command.set_stdout("git_diff_add.txt")


### PR DESCRIPTION
_Fixes a bug found by @timkrins or me... or someone; point is, this is fixed 😇_

You can now redirect the markdown output when using `diff-cover` to stdout