### PR TITLE
Speedup CI tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,6 +5,48 @@ env:
   DEFAULT_PYTHON_VERSION: 3.12
 
 jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        id: setup-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install
+      - name: ruff check
+        continue-on-error: true
+        run: poetry run ruff check
+      - name: ruff format
+        continue-on-error: true
+        run: poetry run ruff check
+      - name: pylint
+        continue-on-error: true
+        run: poetry run pylint .
+      - name: black
+        run: poetry run black --check .
+      - name: isort
+        run: poetry run isort --check .
+      - name: doc8
+        run: poetry run doc8 README.rst --ignore D001
+
   verify:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/diff_cover/config_parser.py
+++ b/diff_cover/config_parser.py
@@ -6,15 +6,12 @@ try:
 
     _HAS_TOML = True
 except ImportError:  # pragma: no cover
-    _HAS_TOML = False
-
-if not _HAS_TOML:
     try:
         import tomllib as toml
 
         _HAS_TOML = True
-    except ImportError:  # pragma: no cover
-        pass
+    except ImportError:
+        _HAS_TOML = False
 
 
 class Tool(enum.Enum):

--- a/poetry.lock
+++ b/poetry.lock
@@ -301,6 +301,24 @@ pycodestyle = ">=2.14.0,<2.15.0"
 pyflakes = ">=3.4.0,<3.5.0"
 
 [[package]]
+name = "flake8-pyproject"
+version = "1.2.3"
+description = "Flake8 plug-in loading the configuration from pyproject.toml"
+optional = false
+python-versions = ">= 3.6"
+groups = ["dev"]
+files = [
+    {file = "flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a"},
+]
+
+[package.dependencies]
+Flake8 = ">=5"
+TOMLi = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["pyTest", "pyTest-cov"]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -882,4 +900,4 @@ toml = ["tomli"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "7f191a558456ba3c5f4c3334d9795f9630ea8bc808e5a3042f8be90c26b61529"
+content-hash = "d615fd4058ecd69309353f692015ac341f3b94f4c33c4b503bee8fa1091da47a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ pytest-datadir = "^1.5.0"
 pytest-mock = "^3.14.0"
 pytest-xdist = "^3.6.1"
 pycodestyle = ">=2.9.1"
-flake8 = "^7.2.0"
-pyflakes = "^3.3.2 "
+flake8-pyproject = "^1.2.3"
+pyflakes = "^3.3.2"
 pylint = "^3.3.4"
 pylint-pytest = "^1.1.8"
 pydocstyle = "^6.1.1"
@@ -72,42 +72,24 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88
-target-version = ['py310']
+target-version = ['py39']
 include = '\.pyi?$'
-exclude = "tests/fixtures/*"
+exclude = "tests/fixtures/*|\\.venv/*"
 
 [tool.isort]
 profile = "black"
-extend_skip = "tests/fixtures/"
+extend_skip = "tests/fixtures/|\\.venv/"
 
 [tool.pylint.master]
 max-line-length = 100
 load-plugins = [
     "pylint_pytest",
 ]
-
-[tool.coverage.run]
-branch = true
-relative_files = true
-parallel = true
-concurrency = ["multiprocessing"]
-source = ["diff_cover"]
-omit = ["./tests/*"]
-
-[tool.coverage.report]
-show_missing = true
-exclude_also = [
-    "if typing.TYPE_CHECKING:",
-    "if TYPE_CHECKING:",
-    "if __name__ == \"__main__\":",
-    "raise NotImplementedError",
-    "raise AssertionError",
-    "^\\s*pass\\s*$",
+ignore = [
+    ".venv",
+    "tests/fixtures"
 ]
-
-[tool.coverage.html]
-show_contexts = true
-skip_covered = false
+ignore-paths = ["tests/fixtures/.*"]
 
 [tool.pylint."messages control"]
 enable = ["all"]
@@ -147,6 +129,40 @@ good-names = [
     "ex",
 ]
 no-docstring-rgx = "^_"
+
+[tool.flake8]
+max-line-length = 100
+exclude = [
+    ".venv",
+    "tests/fixtures"
+]
+ignore = [
+    "E501", # line too long
+    "W503", # line break before binary operator
+]
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+parallel = true
+concurrency = ["multiprocessing"]
+source = ["diff_cover"]
+omit = ["./tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+    "if typing.TYPE_CHECKING:",
+    "if TYPE_CHECKING:",
+    "if __name__ == \"__main__\":",
+    "raise NotImplementedError",
+    "raise AssertionError",
+    "^\\s*pass\\s*$",
+]
+
+[tool.coverage.html]
+show_contexts = true
+skip_covered = false
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"


### PR DESCRIPTION
Depends on: https://github.com/Bachmann1234/diff_cover/pull/518

Because adding windows made tests run slower, we will be avoiding to run `./verify.sh` inside CI and only leave it for the devs.. if that.

There is no point to run all the linters inside the CI for each of the python version + os; once is enough.

~This lowers the current time in CI from ~ 2:30m to ~ 1:44m --- again this will go up... significantly when the windows PR gets merged.~

This lowers the current time in CI from ~[3:30m](https://github.com/Bachmann1234/diff_cover/actions/runs/16456349241) to ~[2:30m](https://github.com/Bachmann1234/diff_cover/actions/runs/16463335648?pr=517).

This also adds:
* flake8, ruff, pylint linters
* flake8-pyproject because flake8 still doesn't support pyproject.toml settings
* adds relevant linter config to pyproject.toml

note: ruff and pylint are failing and they have been set to allow failure-- i will be fixing this in another pr