### PR TITLE
add mypy_driver for diff-quality tool

### DIFF
--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -57,6 +57,7 @@ from diff_cover.violationsreporters.violations_reporter import (
     PylintDriver,
     flake8_driver,
     jshint_driver,
+    mypy_driver,
     pycodestyle_driver,
     pydocstyle_driver,
     pyflakes_driver,
@@ -67,6 +68,7 @@ from diff_cover.violationsreporters.violations_reporter import (
 QUALITY_DRIVERS = {
     "clang": ClangFormatDriver(),
     "cppcheck": CppcheckDriver(),
+    "mypy": mypy_driver,
     "pycodestyle": pycodestyle_driver,
     "pyflakes": pyflakes_driver,
     "pylint": PylintDriver(),

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -530,6 +530,22 @@ class LcovCoverageReporter(BaseViolationReporter):
         return self._info_cache[src_path][1]
 
 
+mypy_driver = RegexBasedDriver(
+    name="mypy",
+    supported_extensions=["py"],
+    command=["mypy"],
+    # Match lines of the form:
+    # main.py:1: error: Function is missing a type annotation  [no-untyped-def]
+    # foo/bar.py:6: error: "int" has no attribute "upper"  [attr-defined]
+    expression=r"^([^:]+):(\d+):\d*:? (.*)$",
+    command_to_check_install=["mypy", "--version"],
+    # mypy exit codes:
+    # 0 - no violations;
+    # 1 - there are violations;
+    # 2 - other error.
+    exit_codes=[0, 1],
+)
+
 pycodestyle_driver = RegexBasedDriver(
     name="pycodestyle",
     supported_extensions=["py"],

--- a/tests/test_violations_reporter.py
+++ b/tests/test_violations_reporter.py
@@ -25,6 +25,7 @@ from diff_cover.violationsreporters.violations_reporter import (
     XmlCoverageReporter,
     flake8_driver,
     jshint_driver,
+    mypy_driver,
     pycodestyle_driver,
     pydocstyle_driver,
     pyflakes_driver,
@@ -2212,6 +2213,31 @@ class TestCppcheckQualityDriverTest:
         assert len(actual_violations) == len(expected_violations)
         for expected in expected_violations:
             assert expected in actual_violations
+
+
+class TestMypyQualityDriverTest:
+    """Tests for mypy quality driver."""
+
+    def test_quality(self, process_patcher):
+        """Integration test."""
+        process_patcher(
+            (
+                'foo/bar.py:6: error: "int" has no attribute "upper"  [attr-defined]',
+                "",
+            )
+        )
+
+        expected_violations = [
+            Violation(
+                line=6,
+                message='error: "int" has no attribute "upper"  [attr-defined]'),
+        ]
+
+        quality = QualityReporter(mypy_driver)
+        actual_violations = quality.violations("foo/bar.py")
+
+        assert quality.name() == "mypy"
+        assert actual_violations == expected_violations
 
 
 class TestRuffCheckQualityDriverTest:

--- a/tests/test_violations_reporter.py
+++ b/tests/test_violations_reporter.py
@@ -2230,7 +2230,8 @@ class TestMypyQualityDriverTest:
         expected_violations = [
             Violation(
                 line=6,
-                message='error: "int" has no attribute "upper"  [attr-defined]'),
+                message='error: "int" has no attribute "upper"  [attr-defined]',
+            ),
         ]
 
         quality = QualityReporter(mypy_driver)


### PR DESCRIPTION
Added mypy_driver to diff-quality tool.

Comparing to `diff-cover + cobertura` way this approach prints errors to the output.
```
> diff-quality --violations=mypy --compare-branch master --options=--strict 
-------------
Diff Quality
Quality Report: mypy
Diff: master...HEAD, staged and unstaged changes
-------------
foo/bar.py (50.0%):
foo/bar.py:1: error: Function is missing a type annotation  [no-untyped-def]
main.py (100%)
-------------
Total:   5 lines
Violations: 1 line
% Quality: 80%
-------------
```
