### PR TITLE
ruff.check: force pylint output format for ruff >= 0.12.9 compatibility

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -563,7 +563,7 @@ ruff_check_driver = RegexBasedDriver(
     # path/to/file.py:328:27 F541 [*] f-string without any placeholders
     # path/to/file.py:418:26 F841 [*] Local variable `e` is assigned to but never used
     expression=r"^([^:]+):(\d+):\d*:? (.*)$",
-    command_to_check_install=["ruff", "--version"],
+    command_to_check_install=["ruff", "--version", "--output-format", "pylint"],
     # ruff exit code is 1 if there are violations
     # https://docs.astral.sh/ruff/linter/#exit-codes
     exit_codes=[0, 1],


### PR DESCRIPTION
Currently diff-quality doesn't match violations with latest ruff version. https://github.com/Bachmann1234/diff_cover/issues/539

It can be quickly fixed by forcing `ruff check` output format.