### PR TITLE
bugfix "ruff.check: force pylint output format for ruff >= 0.12.9 compatibility"

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -574,7 +574,7 @@ pyflakes_driver = RegexBasedDriver(
 ruff_check_driver = RegexBasedDriver(
     name="ruff.check",
     supported_extensions=["py"],
-    command=["ruff", "check"],
+    command=["ruff", "check", "--output-format", "pylint"],
     # Match lines of the form:
     # path/to/file.py:328:27 F541 [*] f-string without any placeholders
     # path/to/file.py:418:26 F841 [*] Local variable `e` is assigned to but never used

--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -579,7 +579,7 @@ ruff_check_driver = RegexBasedDriver(
     # path/to/file.py:328:27 F541 [*] f-string without any placeholders
     # path/to/file.py:418:26 F841 [*] Local variable `e` is assigned to but never used
     expression=r"^([^:]+):(\d+):\d*:? (.*)$",
-    command_to_check_install=["ruff", "--version", "--output-format", "pylint"],
+    command_to_check_install=["ruff", "--version"],
     # ruff exit code is 1 if there are violations
     # https://docs.astral.sh/ruff/linter/#exit-codes
     exit_codes=[0, 1],


### PR DESCRIPTION
Reverts Bachmann1234/diff_cover#541
Fix ruff.check: force pylint output format for ruff >= 0.12.9 compatibility