### PR TITLE
Bugfix: Correct file name matching on Windows

### DIFF
--- a/diff_cover/violationsreporters/violations_reporter.py
+++ b/diff_cover/violationsreporters/violations_reporter.py
@@ -133,7 +133,7 @@ class XmlCoverageReporter(BaseViolationReporter):
 
     def _measured_source_path_matches(self, package_name, file_name, src_path):
         # find src_path in any of the source roots
-        if not src_path.endswith(file_name):
+        if not src_path.endswith(util.to_unix_path(file_name)):
             return False
 
         norm_src_path = os.path.normcase(src_path)


### PR DESCRIPTION
This PR fixes file matching on Windows where `src_path` is lowercased by `os.path.normcase()`, but `file_name` (from the JaCoCo XML) retains its original casing. This mismatch caused the `src_path.endswith(file_name)` check to fail and report no coverage.