### PR TITLE
Fix installation command formatting in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ To install the latest release:
 
 .. code:: bash
 
-    pip install diff_cover
+    pip install diff-cover
 
 
 To install the development version:


### PR DESCRIPTION
I think there's a small typo on the README for installing diff-cover.

Here's the link to the package on pypi.
https://pypi.org/project/diff-cover/