### PR TITLE
Fix --help hiding most CLI options in diff-cover/diff-quality

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -312,7 +312,7 @@ def generate_coverage_report(
 
 
 def handle_old_format(description, argv):
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description=description, add_help=False)
     arg_html = parser.add_argument("--html-report", type=str)
     arg_json = parser.add_argument("--json-report", type=str)
     arg_markdown = parser.add_argument("--markdown-report", type=str)


### PR DESCRIPTION
The deprecated-flag pre-parser in handle_old_format() was created with the default add_help=True, so argparse intercepted --help there and printed help for the 4-option pre-parser instead of the real one. As a result, users saw only --html-report/--json-report/--markdown-report/ --format and assumed flags like --diff-file, --compare-branch, --exclude, etc. didn't exist.

Setting add_help=False on the pre-parser lets --help fall through to parse_coverage_args (and the equivalent diff-quality parser), so the full set of options is displayed.