### PR TITLE
Add --show-covered flag to highlight covered diff lines in HTML report

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -45,6 +45,10 @@ DIFF_RANGE_NOTATION_HELP = (
 )
 QUIET_HELP = "Only print errors and failures"
 SHOW_UNCOVERED = "Show uncovered lines on the console"
+SHOW_COVERED_HELP = (
+    "Also highlight covered diff lines (in green) in the HTML coverage report, "
+    "in addition to the existing missing-line (red) highlighting."
+)
 EXPAND_COVERAGE_REPORT = (
     "Append missing lines in coverage reports based on the hits of the previous line."
 )
@@ -97,6 +101,13 @@ def parse_coverage_args(argv):
 
     parser.add_argument(
         "--show-uncovered", action="store_true", default=None, help=SHOW_UNCOVERED
+    )
+
+    parser.add_argument(
+        "--show-covered",
+        action="store_true",
+        default=None,
+        help=SHOW_COVERED_HELP,
     )
 
     parser.add_argument(
@@ -193,6 +204,7 @@ def parse_coverage_args(argv):
 
     defaults = {
         "show_uncovered": False,
+        "show_covered": False,
         "compare_branch": "origin/main",
         "fail_under": 0,
         "ignore_staged": False,
@@ -223,6 +235,7 @@ def generate_coverage_report(
     src_roots=None,
     quiet=False,
     show_uncovered=False,
+    show_covered=False,
     expand_coverage_report=False,
     total_percent_float=False,
 ):
@@ -263,7 +276,11 @@ def generate_coverage_report(
         if css_url is not None:
             css_url = os.path.relpath(css_file, os.path.dirname(html_report))
         reporter = HtmlReportGenerator(
-            coverage, diff, css_url=css_url, total_percent_float=total_percent_float
+            coverage,
+            diff,
+            css_url=css_url,
+            total_percent_float=total_percent_float,
+            show_covered=show_covered,
         )
         with open_file(html_report, "wb") as output_file:
             reporter.generate_report(output_file)
@@ -398,6 +415,7 @@ def main(argv=None, directory=None):
         src_roots=arg_dict["src_roots"],
         quiet=quiet,
         show_uncovered=arg_dict["show_uncovered"],
+        show_covered=arg_dict["show_covered"],
         expand_coverage_report=arg_dict["expand_coverage_report"],
         total_percent_float=arg_dict["total_percent_float"],
     )

--- a/diff_cover/report_generator.py
+++ b/diff_cover/report_generator.py
@@ -295,6 +295,7 @@ class TemplateReportGenerator(BaseReportGenerator):
         diff_reporter,
         css_url=None,
         total_percent_float=False,
+        show_covered=False,
     ):
         super().__init__(
             violations_reporter,
@@ -302,6 +303,11 @@ class TemplateReportGenerator(BaseReportGenerator):
             total_percent_float=total_percent_float,
         )
         self.css_url = css_url
+        # When True, the rendered HTML snippet for each source file will
+        # additionally highlight covered diff lines (in green) on top of
+        # the existing violation (red) highlighting. Defaults to False to
+        # preserve historical behaviour.
+        self.show_covered = show_covered
 
     def generate_report(self, output_file):
         """
@@ -406,9 +412,12 @@ class TemplateReportGenerator(BaseReportGenerator):
         # If we cannot load the file, then fail gracefully
         formatted_snippets = {"html": [], "markdown": [], "terminal": []}
         if self.include_snippets:
+            covered_lines = stats["covered_lines"] if self.show_covered else None
             with contextlib.suppress(OSError):
                 formatted_snippets = Snippet.load_formatted_snippets(
-                    src_path, stats["violation_lines"]
+                    src_path,
+                    stats["violation_lines"],
+                    covered_lines=covered_lines,
                 )
 
         stats.update(

--- a/diff_cover/snippets.py
+++ b/diff_cover/snippets.py
@@ -4,6 +4,7 @@ in HTML reports.
 """
 
 import contextlib
+import re
 from tokenize import open as openpy
 
 import chardet
@@ -23,7 +24,10 @@ class Snippet:
     """
 
     VIOLATION_COLOR = "#ffcccc"
+    COVERED_COLOR = "#ddffdd"
     DIV_CSS_CLASS = "snippet"
+    COVERED_LINE_CSS_CLASS = "diff-cover-covered-line"
+    LINESPANS_PREFIX = "diff-cover-src-line"
 
     # Number of extra lines to include before and after
     # each snippet to provide context.
@@ -50,6 +54,7 @@ class Snippet:
         last_line,
         violation_lines,
         lexer_name,
+        covered_lines=None,
     ):
         """
         Create a source code snippet.
@@ -75,6 +80,10 @@ class Snippet:
         programming language for this snippet.
         See https://pygments.org/docs/lexers/
 
+        `covered_lines` is an optional list of line numbers
+        to highlight as covered. When omitted (the default),
+        no covered-line highlighting is rendered.
+
         Raises a `ValueError` if `start_line` is less than 1
         """
         if start_line < 1:
@@ -86,6 +95,7 @@ class Snippet:
         self._last_line = last_line
         self._violation_lines = violation_lines
         self._lexer_name = lexer_name
+        self._covered_lines = covered_lines or []
 
     @classmethod
     def style_defs(cls):
@@ -95,21 +105,76 @@ class Snippet:
         """
         formatter = HtmlFormatter()
         formatter.style.highlight_color = cls.VIOLATION_COLOR
-        return formatter.get_style_defs()
+        base_styles = formatter.get_style_defs()
+        # Append a rule for covered-line highlighting.
+        covered_style = (
+            f".{cls.COVERED_LINE_CSS_CLASS} "
+            f"{{ background-color: {cls.COVERED_COLOR}; }}"
+        )
+        return f"{base_styles}\n{covered_style}"
 
     def html(self):
         """
         Return an HTML representation of the snippet.
+
+        Violation lines are highlighted via Pygments' built-in
+        `hl_lines` mechanism. When the snippet was constructed with
+        `covered_lines`, those lines are additionally marked by adding
+        the covered-line CSS class to their per-line span, produced via
+        the `linespans` formatter option.
         """
-        formatter = HtmlFormatter(
+        formatter_kwargs = dict(
             cssclass=self.DIV_CSS_CLASS,
             linenos=True,
             linenostart=self._start_line,
             hl_lines=self._shift_lines(self._violation_lines, self._start_line),
             lineanchors=self._src_filename,
         )
+        # Only enable per-line `<span id="...">` wrapping when we actually
+        # need it for covered-line highlighting. This keeps the rendered
+        # HTML byte-for-byte identical to the historical output when no
+        # covered lines are supplied.
+        if self._covered_lines:
+            formatter_kwargs["linespans"] = self.LINESPANS_PREFIX
 
-        return pygments.format(self.src_tokens(), formatter)
+        rendered = pygments.format(
+            self.src_tokens(), HtmlFormatter(**formatter_kwargs)
+        )
+
+        if self._covered_lines:
+            # NOTE: do NOT shift these line numbers. Unlike `hl_lines`
+            # (which is snippet-relative, 1-based), Pygments' `linespans`
+            # IDs are emitted using the same numbering as `linenostart`,
+            # i.e. the absolute file line number. So we match the raw
+            # values from `_covered_lines` directly.
+            rendered = self._mark_covered_lines(rendered, self._covered_lines)
+
+        return rendered
+
+    @classmethod
+    def _mark_covered_lines(cls, html, covered_file_lines):
+        """
+        Add the covered-line CSS class to per-line spans whose line
+        number is in `covered_file_lines`.
+
+        `covered_file_lines` are absolute (file-relative) line numbers,
+        matching the IDs that Pygments emits via `linespans` when
+        `linenostart` is set to the snippet's starting line number.
+        """
+        wanted = set(covered_file_lines)
+        if not wanted:
+            return html
+
+        prefix = cls.LINESPANS_PREFIX
+        css_class = cls.COVERED_LINE_CSS_CLASS
+
+        def _replace(match):
+            line_num = int(match.group(1))
+            if line_num in wanted:
+                return f'<span id="{prefix}-{line_num}" class="{css_class}">'
+            return match.group(0)
+
+        return re.sub(rf'<span id="{re.escape(prefix)}-(\d+)">', _replace, html)
 
     def markdown(self):
         """
@@ -174,24 +239,40 @@ class Snippet:
         return "".join([val for _, val in self._src_tokens])
 
     @classmethod
-    def load_formatted_snippets(cls, src_path, violation_lines):
+    def load_formatted_snippets(cls, src_path, violation_lines, covered_lines=None):
         """
         Load snippets from the file at `src_path` and format
         them as HTML and as plain text.
         Returns a dictionary containing the two types of formatting
         results for code snippets.
 
+        If `covered_lines` is provided (non-empty), the HTML output will
+        additionally render snippets around those lines and highlight
+        them as covered. Markdown and terminal output is unchanged
+        regardless of `covered_lines`, to keep those formats stable.
+
         See `load_snippets()` for details.
         """
 
-        # load once...
-        snippet_list = cls.load_snippets(src_path, violation_lines)
+        # Snippets used for markdown/terminal output keep the historical
+        # behaviour: ranges only around violation lines, no covered-line
+        # information attached.
+        violation_only_snippets = cls.load_snippets(src_path, violation_lines)
 
-        # ...render twice in different formats
+        if covered_lines:
+            # HTML rendering also visualises covered diff lines, so widen
+            # the snippet ranges to include them and pass the covered list
+            # through to the snippet for per-line highlighting.
+            html_snippets = cls.load_snippets(
+                src_path, violation_lines, covered_lines
+            )
+        else:
+            html_snippets = violation_only_snippets
+
         return {
-            "html": [snippet.html() for snippet in snippet_list],
-            "markdown": [snippet.markdown() for snippet in snippet_list],
-            "terminal": [snippet.terminal() for snippet in snippet_list],
+            "html": [snippet.html() for snippet in html_snippets],
+            "markdown": [snippet.markdown() for snippet in violation_only_snippets],
+            "terminal": [snippet.terminal() for snippet in violation_only_snippets],
         }
 
     @classmethod
@@ -223,11 +304,16 @@ class Snippet:
         return contents
 
     @classmethod
-    def load_snippets(cls, src_path, violation_lines):
+    def load_snippets(cls, src_path, violation_lines, covered_lines=None):
         """
         Load snippets from the file at `src_path` to show
         violations on lines in the list `violation_lines`
         (list of line numbers, starting at index 0).
+
+        If `covered_lines` is provided, those lines are also treated as
+        "interesting" when computing snippet ranges (so a fully-covered
+        file still yields snippets) and are stored on the resulting
+        `Snippet` instances for use during rendering.
 
         The file at `src_path` should be a text file (not binary).
 
@@ -237,9 +323,15 @@ class Snippet:
         """
         contents = cls.load_contents(src_path)
 
-        # Construct a list of snippet ranges
+        # Construct a list of snippet ranges. When `covered_lines` is
+        # provided, expand the set of "interesting" lines so we also
+        # render context around covered diff lines, not just violations.
         src_lines = contents.split("\n")
-        snippet_ranges = cls._snippet_ranges(len(src_lines), violation_lines)
+        if covered_lines:
+            interesting_lines = sorted(set(violation_lines) | set(covered_lines))
+        else:
+            interesting_lines = violation_lines
+        snippet_ranges = cls._snippet_ranges(len(src_lines), interesting_lines)
 
         # Parse the source into tokens
         token_stream, lexer = cls._parse_src(contents, src_path)
@@ -248,7 +340,15 @@ class Snippet:
         token_groups = cls._group_tokens(token_stream, snippet_ranges)
 
         return [
-            Snippet(tokens, src_path, start, end, violation_lines, lexer.name)
+            Snippet(
+                tokens,
+                src_path,
+                start,
+                end,
+                violation_lines,
+                lexer.name,
+                covered_lines=covered_lines,
+            )
             for (start, end), tokens in sorted(token_groups.items())
         ]
 

--- a/diff_cover/snippets.py
+++ b/diff_cover/snippets.py
@@ -137,9 +137,7 @@ class Snippet:
         if self._covered_lines:
             formatter_kwargs["linespans"] = self.LINESPANS_PREFIX
 
-        rendered = pygments.format(
-            self.src_tokens(), HtmlFormatter(**formatter_kwargs)
-        )
+        rendered = pygments.format(self.src_tokens(), HtmlFormatter(**formatter_kwargs))
 
         if self._covered_lines:
             # NOTE: do NOT shift these line numbers. Unlike `hl_lines`
@@ -263,9 +261,7 @@ class Snippet:
             # HTML rendering also visualises covered diff lines, so widen
             # the snippet ranges to include them and pass the covered list
             # through to the snippet for per-line highlighting.
-            html_snippets = cls.load_snippets(
-                src_path, violation_lines, covered_lines
-            )
+            html_snippets = cls.load_snippets(src_path, violation_lines, covered_lines)
         else:
             html_snippets = violation_only_snippets
 

--- a/tests/test_diff_cover_tool.py
+++ b/tests/test_diff_cover_tool.py
@@ -37,6 +37,16 @@ def test_parse_with_no_report():
     assert not arg_dict["ignore_unstaged"]
 
 
+def test_show_covered_defaults_false():
+    arg_dict = parse_coverage_args(["reports/coverage.xml"])
+    assert arg_dict["show_covered"] is False
+
+
+def test_show_covered_flag():
+    arg_dict = parse_coverage_args(["reports/coverage.xml", "--show-covered"])
+    assert arg_dict["show_covered"] is True
+
+
 def test_parse_with_multiple_reports():
     argv = [
         "reports/coverage.xml",

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -498,6 +498,41 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
         expected = load_fixture("html_report.html")
         self.assert_report(expected)
 
+    @pytest.mark.usefixtures("use_default_values")
+    def test_show_covered_passes_covered_lines_to_snippets(
+        self, coverage, diff
+    ):
+        """
+        When `show_covered=True`, the html reporter should pass each
+        source file's covered lines into `Snippet.load_formatted_snippets`
+        so the snippet renderer can highlight them.
+        """
+        report = HtmlReportGenerator(coverage, diff, show_covered=True)
+        report.generate_report(BytesIO())
+
+        calls = self._load_formatted_snippets.call_args_list
+        assert calls, "Expected snippet loading to be invoked"
+        for call in calls:
+            assert call.kwargs.get("covered_lines"), (
+                "Expected covered_lines to be forwarded when show_covered=True"
+            )
+
+    @pytest.mark.usefixtures("use_default_values")
+    def test_show_covered_default_false_does_not_pass_covered_lines(
+        self, coverage, diff
+    ):
+        """
+        With the default `show_covered=False`, no covered_lines should be
+        passed to the snippet loader, preserving the historical behaviour.
+        """
+        report = HtmlReportGenerator(coverage, diff)
+        report.generate_report(BytesIO())
+
+        calls = self._load_formatted_snippets.call_args_list
+        assert calls, "Expected snippet loading to be invoked"
+        for call in calls:
+            assert call.kwargs.get("covered_lines") is None
+
     def test_empty_report(self):
         # Have the dependencies return an empty report
         # (this is the default)

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -499,9 +499,7 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
         self.assert_report(expected)
 
     @pytest.mark.usefixtures("use_default_values")
-    def test_show_covered_passes_covered_lines_to_snippets(
-        self, coverage, diff
-    ):
+    def test_show_covered_passes_covered_lines_to_snippets(self, coverage, diff):
         """
         When `show_covered=True`, the html reporter should pass each
         source file's covered lines into `Snippet.load_formatted_snippets`
@@ -513,9 +511,9 @@ class TestHtmlReportGenerator(BaseReportGeneratorTest):
         calls = self._load_formatted_snippets.call_args_list
         assert calls, "Expected snippet loading to be invoked"
         for call in calls:
-            assert call.kwargs.get("covered_lines"), (
-                "Expected covered_lines to be forwarded when show_covered=True"
-            )
+            assert call.kwargs.get(
+                "covered_lines"
+            ), "Expected covered_lines to be forwarded when show_covered=True"
 
     @pytest.mark.usefixtures("use_default_values")
     def test_show_covered_default_false_does_not_pass_covered_lines(

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -236,6 +236,134 @@ def test_no_violations(tmpfile):
     _assert_line_range(src_path, violations, expected_ranges)
 
 
+def test_load_snippets_no_violations_with_covered(tmpfile):
+    """
+    A fully-covered file (no violations) should still produce snippet
+    ranges when `covered_lines` is supplied, expanded by the usual
+    NUM_CONTEXT_LINES window.
+    """
+    src_path = tmpfile(10)
+    snippets = Snippet.load_snippets(src_path, [], covered_lines=[5, 6])
+    assert len(snippets) == 1
+    # Lines 5 and 6 are interesting; expand by NUM_CONTEXT_LINES (4) on each
+    # side, clamped to [1, num_src_lines].
+    assert snippets[0].line_range() == (1, 10)
+
+
+def test_html_marks_covered_lines():
+    """
+    When `covered_lines` is supplied, the rendered HTML should wrap each
+    line in a `<span id=...>` and add the covered-line CSS class to spans
+    whose line numbers are in `covered_lines`.
+    """
+    snippet = Snippet(
+        SRC_TOKENS,
+        "test.py",
+        start_line=1,
+        last_line=3,
+        violation_lines=[3],
+        lexer_name=None,
+        covered_lines=[1, 2],
+    )
+    rendered = snippet.html()
+
+    # Linespans should now be present, since covered_lines is non-empty.
+    assert 'id="diff-cover-src-line-1"' in rendered
+    assert 'id="diff-cover-src-line-2"' in rendered
+    assert 'id="diff-cover-src-line-3"' in rendered
+
+    # Lines 1 and 2 should be marked as covered.
+    assert (
+        f'<span id="diff-cover-src-line-1" class="{Snippet.COVERED_LINE_CSS_CLASS}">'
+        in rendered
+    )
+    assert (
+        f'<span id="diff-cover-src-line-2" class="{Snippet.COVERED_LINE_CSS_CLASS}">'
+        in rendered
+    )
+    # Line 3 is a violation only and should NOT be marked covered.
+    assert (
+        f'<span id="diff-cover-src-line-3" class="{Snippet.COVERED_LINE_CSS_CLASS}">'
+        not in rendered
+    )
+    # Violation highlighting (.hll) should still be present for line 3.
+    assert "hll" in rendered
+
+
+def test_html_without_covered_lines_keeps_legacy_output():
+    """
+    With no covered lines supplied, the rendered HTML must not include
+    the new `linespans` per-line wrappers. This preserves byte-for-byte
+    backwards compatibility with the historical HTML report output.
+    """
+    snippet = Snippet(
+        SRC_TOKENS,
+        "test.py",
+        start_line=1,
+        last_line=3,
+        violation_lines=[3],
+        lexer_name=None,
+    )
+    rendered = snippet.html()
+    assert "diff-cover-src-line-" not in rendered
+    assert Snippet.COVERED_LINE_CSS_CLASS not in rendered
+
+
+def test_style_defs_includes_covered_class():
+    style_str = Snippet.style_defs()
+    assert Snippet.COVERED_LINE_CSS_CLASS in style_str
+    assert Snippet.COVERED_COLOR in style_str
+
+
+def test_html_marks_covered_lines_with_nonzero_start_line():
+    """
+    Pygments' `linespans` IDs use `linenostart`-based (file-absolute)
+    line numbers, while `hl_lines` is snippet-relative. When the snippet
+    does not start at line 1 we must NOT shift the covered line numbers
+    when matching span IDs.
+    """
+    # Build a 5-line snippet covering source lines 58..62.
+    src_tokens = [
+        (Token.Text, "Line 58\n"),
+        (Token.Text, "Line 59\n"),
+        (Token.Text, "Line 60\n"),
+        (Token.Text, "Line 61\n"),
+        (Token.Text, "Line 62\n"),
+    ]
+    snippet = Snippet(
+        src_tokens,
+        "test.py",
+        start_line=58,
+        last_line=62,
+        violation_lines=[60],
+        lexer_name=None,
+        covered_lines=[58, 59, 62],
+    )
+    rendered = snippet.html()
+
+    # IDs are file-absolute (58..62), matching `linenostart`.
+    assert 'id="diff-cover-src-line-58"' in rendered
+    assert 'id="diff-cover-src-line-62"' in rendered
+
+    # Covered lines should be tagged using their file-absolute IDs.
+    for n in (58, 59, 62):
+        assert (
+            f'<span id="diff-cover-src-line-{n}" class="{Snippet.COVERED_LINE_CSS_CLASS}">'
+            in rendered
+        ), f"Expected covered-line class on line {n}"
+
+    # Violation line (60) is in the middle of the snippet and must NOT
+    # carry the covered class.
+    assert (
+        f'<span id="diff-cover-src-line-60" class="{Snippet.COVERED_LINE_CSS_CLASS}">'
+        not in rendered
+    )
+    # Sanity-check: violation highlighting still applies. `hl_lines` is
+    # snippet-relative, so line 60 is offset 3 within the snippet; the
+    # `.hll` class should be present somewhere in the rendered HTML.
+    assert "hll" in rendered
+
+
 def test_end_range_on_violation(tmpfile):
     src_path = tmpfile(40)
 


### PR DESCRIPTION
Introduce a new `--show-covered` CLI option for diff-cover that, when enabled, additionally highlights covered diff lines (in green) in the HTML coverage report alongside the existing red highlighting for missing lines.