### PR TITLE
fix(config): honor format option from config file

### DIFF
--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -76,6 +76,16 @@ def format_type(value):
     return dict((item.split(":", 1) for item in value.split(",")) if value else {})
 
 
+def normalize_format(config):
+    """
+    Config files provide ``format`` as a raw string, because ``type=`` is only
+    applied to values that come from the command line. Parse it the same way.
+    """
+    if isinstance(config.get("format"), str):
+        config["format"] = format_type(config["format"])
+    return config
+
+
 def parse_coverage_args(argv):
     """
     Parse command line arguments, returning a dict of
@@ -99,7 +109,7 @@ def parse_coverage_args(argv):
     parser.add_argument(
         "--format",
         type=format_type,
-        default="",
+        default=None,
         help=FORMAT_HELP,
     )
 
@@ -217,6 +227,7 @@ def parse_coverage_args(argv):
         "show_uncovered": False,
         "show_covered": False,
         "compare_branch": "origin/main",
+        "format": {},
         "fail_under": 0,
         "ignore_staged": False,
         "ignore_unstaged": False,
@@ -230,7 +241,9 @@ def parse_coverage_args(argv):
         "total_percent_float": False,
     }
 
-    return get_config(parser=parser, argv=argv, defaults=defaults, tool=Tool.DIFF_COVER)
+    return normalize_format(
+        get_config(parser=parser, argv=argv, defaults=defaults, tool=Tool.DIFF_COVER)
+    )
 
 
 def generate_coverage_report(

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -33,6 +33,7 @@ from diff_cover.diff_cover_tool import (
     TOTAL_PERCENT_FLOAT_HELP,
     format_type,
     handle_old_format,
+    normalize_format,
 )
 from diff_cover.diff_reporter import GitDiffReporter
 from diff_cover.git_diff import GitDiffTool
@@ -119,7 +120,7 @@ def parse_quality_args(argv):
     parser.add_argument(
         "--format",
         type=format_type,
-        default="",
+        default=None,
         help=FORMAT_HELP,
     )
 
@@ -211,6 +212,7 @@ def parse_quality_args(argv):
     defaults = {
         "ignore_whitespace": False,
         "compare_branch": "origin/main",
+        "format": {},
         "diff_range_notation": "...",
         "input_reports": [],
         "fail_under": 0,
@@ -221,8 +223,8 @@ def parse_quality_args(argv):
         "total_percent_float": False,
     }
 
-    return get_config(
-        parser=parser, argv=argv, defaults=defaults, tool=Tool.DIFF_QUALITY
+    return normalize_format(
+        get_config(parser=parser, argv=argv, defaults=defaults, tool=Tool.DIFF_QUALITY)
     )
 
 

--- a/tests/test_diff_cover_tool.py
+++ b/tests/test_diff_cover_tool.py
@@ -156,3 +156,31 @@ def test_parse_with_include():
 
 def test_parse_with_exclude():
     _test_parse_with_path_patterns("exclude")
+
+
+def test_parse_format_from_config_file(tmp_path):
+    config_file = tmp_path / "diff_cover.toml"
+    config_file.write_text('[tool.diff_cover]\nformat = "html:report.html"\n')
+
+    arg_dict = parse_coverage_args(
+        ["reports/coverage.xml", "--config-file", str(config_file)]
+    )
+
+    assert arg_dict["format"] == {"html": "report.html"}
+
+
+def test_parse_format_cli_overrides_config_file(tmp_path):
+    config_file = tmp_path / "diff_cover.toml"
+    config_file.write_text('[tool.diff_cover]\nformat = "html:report.html"\n')
+
+    arg_dict = parse_coverage_args(
+        [
+            "reports/coverage.xml",
+            "--config-file",
+            str(config_file),
+            "--format",
+            "json:report.json",
+        ]
+    )
+
+    assert arg_dict["format"] == {"json": "report.json"}

--- a/tests/test_diff_quality_main.py
+++ b/tests/test_diff_quality_main.py
@@ -147,3 +147,14 @@ def _run_main(report, argv):
     quality_reporter = report.call_args[0][0]
     assert quality_reporter.driver.name == "pylint"
     assert quality_reporter.options == "--foobar"
+
+
+def test_parse_format_from_config_file(tmp_path):
+    config_file = tmp_path / "diff_quality.toml"
+    config_file.write_text('[tool.diff_quality]\nformat = "html:report.html"\n')
+
+    arg_dict = parse_quality_args(
+        ["--violations", "pylint", "--config-file", str(config_file)]
+    )
+
+    assert arg_dict.get("format") == {"html": "report.html"}


### PR DESCRIPTION
Fixes #588

`--format` was registered with a non-`None` argparse default (`""`), so the CLI value always won in `get_config` and a `format` set in `[tool.diff_cover]` / `[tool.diff_quality]` was silently discarded — no HTML/JSON/Markdown report was written. The default now lives in the `defaults` dict, and the raw config-file string is parsed with `format_type` (argparse `type=` only applies to command-line values). CLI still overrides the config file.
