### PR TITLE
fix: report a missing git instead of an unhandled FileNotFoundError

### DIFF
--- a/diff_cover/command_runner.py
+++ b/diff_cover/command_runner.py
@@ -1,10 +1,22 @@
 import subprocess
 import sys
 
+GIT_INSTALL_URL = "https://git-scm.com/book/en/v2/Getting-Started-Installing-Git"
+
 
 class CommandError(Exception):
     """
     Error raised when a command being executed returns an error
+    """
+
+
+class ExecutableNotFoundError(CommandError):
+    """
+    Error raised when the executable of a command cannot be found at all.
+
+    This is a `CommandError` so that existing handling keeps working, but a
+    distinct type so the command line tools can tell "your tooling is not
+    installed" apart from "the command ran and failed".
     """
 
 
@@ -24,7 +36,12 @@ def execute(command, exit_codes=None):
         exit_codes = [0]
 
     stdout_pipe = subprocess.PIPE
-    with subprocess.Popen(command, stdout=stdout_pipe, stderr=stdout_pipe) as process:
+    try:
+        popen = subprocess.Popen(command, stdout=stdout_pipe, stderr=stdout_pipe)
+    except FileNotFoundError as exc:
+        raise ExecutableNotFoundError(_executable_not_found_message(command)) from exc
+
+    with popen as process:
         try:
             stdout, stderr = process.communicate()
         except OSError:
@@ -50,6 +67,20 @@ def run_command_for_code(command):
     except FileNotFoundError:
         return 1
     return process.returncode
+
+
+def _executable_not_found_message(command):
+    """
+    Explain that the executable of `command` is not installed or not on PATH.
+    """
+    executable = _ensure_unicode(command[0]) if command else ""
+    message = (
+        f"'{executable}' was not found. diff-cover needs '{executable}' to be "
+        "installed and on your PATH in order to run."
+    )
+    if executable == "git":
+        message += f" See {GIT_INSTALL_URL} for installation instructions."
+    return message
 
 
 def _ensure_unicode(text):

--- a/diff_cover/diff_cover_tool.py
+++ b/diff_cover/diff_cover_tool.py
@@ -7,6 +7,7 @@ import warnings
 import xml.etree.ElementTree as etree
 
 from diff_cover import DESCRIPTION, VERSION
+from diff_cover.command_runner import ExecutableNotFoundError
 from diff_cover.config_parser import Tool, get_config
 from diff_cover.diff_reporter import GitDiffReporter
 from diff_cover.git_diff import GitDiffFileTool, GitDiffTool
@@ -418,7 +419,11 @@ def main(argv=None, directory=None):
     level = logging.ERROR if quiet else logging.WARNING
     logging.basicConfig(format="%(message)s", level=level)
 
-    GitPathTool.set_cwd(directory)
+    try:
+        GitPathTool.set_cwd(directory)
+    except ExecutableNotFoundError as exc:
+        LOGGER.error("%s", exc)
+        return 1
     fail_under = arg_dict.get("fail_under")
     diff_tool = None
 

--- a/diff_cover/diff_quality_tool.py
+++ b/diff_cover/diff_quality_tool.py
@@ -14,6 +14,7 @@ import pluggy
 
 import diff_cover
 from diff_cover import hookspecs
+from diff_cover.command_runner import ExecutableNotFoundError
 from diff_cover.config_parser import Tool, get_config
 from diff_cover.diff_cover_tool import (
     COMPARE_BRANCH_HELP,
@@ -339,7 +340,11 @@ def main(argv=None, directory=None):
     level = logging.ERROR if quiet else logging.WARNING
     logging.basicConfig(format="%(message)s", level=level)
 
-    GitPathTool.set_cwd(directory)
+    try:
+        GitPathTool.set_cwd(directory)
+    except ExecutableNotFoundError as exc:
+        LOGGER.error("%s", exc)
+        return 1
     fail_under = arg_dict.get("fail_under")
     tool = arg_dict["violations"]
     user_options = arg_dict.get("options")

--- a/tests/test_command_runner_missing_executable.py
+++ b/tests/test_command_runner_missing_executable.py
@@ -1,0 +1,91 @@
+# pylint: disable=missing-function-docstring
+
+"""Tests for the message shown when a required executable is not on PATH.
+
+See https://github.com/Bachmann1234/diff_cover/issues/303
+"""
+
+import pytest
+
+from diff_cover.command_runner import (
+    CommandError,
+    ExecutableNotFoundError,
+    execute,
+)
+
+
+@pytest.fixture
+def missing_git(mocker):
+    """Make every subprocess launch fail the way a missing `git` does."""
+    return mocker.patch(
+        "diff_cover.command_runner.subprocess.Popen",
+        side_effect=FileNotFoundError(2, "No such file or directory", "git"),
+    )
+
+
+@pytest.fixture
+def failing_git(mocker):
+    """Make `git` run and fail, which is a different thing entirely."""
+    process = mocker.Mock()
+    process.returncode = 1
+    process.communicate.return_value = (b"", b"fatal: not a git repository")
+    popen = mocker.patch("diff_cover.command_runner.subprocess.Popen")
+    popen.return_value.__enter__.return_value = process
+    popen.return_value.__exit__.return_value = None
+    return popen
+
+
+def test_execute_turns_a_missing_executable_into_a_helpful_error(missing_git):
+    with pytest.raises(ExecutableNotFoundError) as exc_info:
+        execute(["git", "rev-parse", "--show-toplevel"])
+
+    message = str(exc_info.value)
+    assert "git" in message
+    assert "PATH" in message
+    assert "https://git-scm.com/" in message
+
+
+def test_the_new_error_stays_a_command_error(missing_git):
+    """Callers that already catch CommandError must keep working."""
+    assert issubclass(ExecutableNotFoundError, CommandError)
+    with pytest.raises(CommandError):
+        execute(["git", "rev-parse", "--show-toplevel"])
+
+
+def test_execute_does_not_link_git_docs_for_other_executables(mocker):
+    mocker.patch(
+        "diff_cover.command_runner.subprocess.Popen",
+        side_effect=FileNotFoundError(2, "No such file or directory", "pycodestyle"),
+    )
+
+    with pytest.raises(ExecutableNotFoundError) as exc_info:
+        execute(["pycodestyle", "--version"])
+
+    message = str(exc_info.value)
+    assert "pycodestyle" in message
+    assert "git-scm.com" not in message
+
+
+def test_diff_cover_main_reports_missing_git_without_a_traceback(missing_git, caplog):
+    from diff_cover.diff_cover_tool import main
+
+    assert main(["diff-cover", "coverage.xml"]) == 1
+    assert "PATH" in caplog.text
+
+
+def test_diff_quality_main_reports_missing_git_without_a_traceback(missing_git, caplog):
+    from diff_cover.diff_quality_tool import main
+
+    assert main(["diff-quality", "--violations", "pycodestyle"]) == 1
+    assert "PATH" in caplog.text
+
+
+def test_a_command_that_runs_and_fails_is_left_alone(failing_git):
+    """Control. Green before and after: only a *missing* binary is reworded."""
+    with pytest.raises(CommandError) as exc_info:
+        execute(["git", "status"])
+
+    assert not isinstance(exc_info.value, ExecutableNotFoundError)
+    message = str(exc_info.value)
+    assert "fatal: not a git repository" in message
+    assert "PATH" not in message

--- a/tests/test_command_runner_missing_executable.py
+++ b/tests/test_command_runner_missing_executable.py
@@ -8,6 +8,7 @@ See https://github.com/Bachmann1234/diff_cover/issues/303
 import pytest
 
 from diff_cover.command_runner import (
+    GIT_INSTALL_URL,
     CommandError,
     ExecutableNotFoundError,
     execute,
@@ -42,7 +43,7 @@ def test_execute_turns_a_missing_executable_into_a_helpful_error(missing_git):
     message = str(exc_info.value)
     assert "git" in message
     assert "PATH" in message
-    assert "https://git-scm.com/" in message
+    assert message.endswith(f"See {GIT_INSTALL_URL} for installation instructions.")
 
 
 def test_the_new_error_stays_a_command_error(missing_git):
@@ -63,7 +64,7 @@ def test_execute_does_not_link_git_docs_for_other_executables(mocker):
 
     message = str(exc_info.value)
     assert "pycodestyle" in message
-    assert "git-scm.com" not in message
+    assert GIT_INSTALL_URL not in message
 
 
 def test_diff_cover_main_reports_missing_git_without_a_traceback(missing_git, caplog):


### PR DESCRIPTION
Closes #303.

## Problem

With git not installed (or not on `PATH`), both entry points end in a traceback:

```
Traceback (most recent call last):
  ...
  File ".../diff_cover/command_runner.py", line 27, in execute
    with subprocess.Popen(command, stdout=stdout_pipe, stderr=stdout_pipe) as process:
FileNotFoundError: [Errno 2] No such file or directory: 'git'
```

Two things are going on:

1. `command_runner.execute` puts `subprocess.Popen(...)` **outside** the `try`. The
   `try` only covers `process.communicate()`, so the `FileNotFoundError` that `Popen`
   raises when the executable does not exist escapes untouched.

2. Both `main()` functions call `GitPathTool.set_cwd(directory)` **before** their own
   error handling starts. `diff_quality_tool.main` already has

   ```python
   except OSError as exc:
       LOGGER.error("Failure: '%s'", str(exc))
       return 1
   ```

   and `FileNotFoundError` is an `OSError` — the handler for this case is already
   written, the failure just happens a few lines above the block that would catch it.
   `diff_cover_tool.main` has no handling at that point at all.

## Precedent

This is the same class of defect as #378 ("Running diff-quality with a tool which is
not installed gives FileNotFoundError rather than helpful message"), fixed by #380.
That fix landed in `run_command_for_code` and covers "the linter is not installed";
the "git is not installed" path goes through `execute` and was left as it was.

## Fix

- `ExecutableNotFoundError(CommandError)` — a subclass, so `git_diff.py`'s
  `except CommandError` and every other existing handler keep working unchanged.
- `execute()` raises it for the `FileNotFoundError` from `Popen` only, with the message
  #303 asked for. The git-scm.com link is added only when the missing binary is `git`.
- Both `main()` functions wrap `set_cwd` and report through `LOGGER.error`, returning 1.

## The narrow catch is deliberate

My first version caught `CommandError` wholesale in `main()`, and two of your existing
tests rejected it —
`tests/test_integration.py::TestDiffCoverIntegration::test_git_diff_error` and
`::TestDiffQualityIntegration::test_git_diff_error_diff_quality`. Both set up a git that
runs and exits 1, and both require `CommandError` to propagate out of `main()`. That is
the project saying "the command ran and failed" and "there is no command to run" are
different things, which is where the separate subclass came from. Both tests pass here.

## Tests

`tests/test_command_runner_missing_executable.py`, six cases: `execute()`, a non-git
binary getting no git link, the subclass relationship, both `main()` functions, and

```python
def test_a_command_that_runs_and_fails_is_left_alone(failing_git):
    """Control. Green before and after: only a *missing* binary is reworded."""
```

which is green on both sides — that is what shows the error semantics did not move.

## Verification

| | result |
|---|---|
| `main` (e34eec3, release 10.5.0), whole suite | 382 passed, 0 failed |
| probe against the existing API before the fix | 3 defects out of 3 — raw `FileNotFoundError` escaped `execute()` and both `main()`s |
| control before the fix (git present but failing) | handled as `CommandError` — silent, as it must be |
| this branch, whole suite | **388 passed, 0 failed** |
| new failures against `main` | **none** |
| reproducer from the issue, after the fix | one line of text, exit code 1, no traceback |
| blocking lint (`black`, `isort`, `doc8`) | clean |

`ruff` and `pylint` are `continue-on-error: true` in `verify.yaml`, so I checked the
blocking three; `diff-quality` on this diff reports 100% for pyflakes.
